### PR TITLE
Minor inventory listing adjustment

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -1294,7 +1294,7 @@ Instead of taking inventory when the current inventory listing style is utilitar
 		if packed count is 0:
 			say line break;
 		say "We're wearing [the list of things worn by the player].";
-	else if the packed count is greater than 0:
+	else if the packed count is greater than 0 or the player carries the backpack:
 		say paragraph break.
 			
 


### PR DESCRIPTION
This inserts a missing paragraph break between "None of that is in the backpack" and the command prompt when the former line is the last of the inventory listing. 

(It will be the last line if the player is not wearing anything and carrying an empty backpack.)