### PR TITLE
Change Ultra Undo to limit the number of possible undo filenames.

### DIFF
--- a/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
+++ b/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
@@ -1,4 +1,4 @@
-Version 1/140320 of Ultra Undo (for Glulx only) by Dannii Willis begins here.
+Version 1/160429 of Ultra Undo (for Glulx only) by Dannii Willis begins here.
 
 "Handles undo using external files for very big story files"
 
@@ -18,6 +18,8 @@ Global ultra_undo_needed = 0;
 	if ( res == 1 ) ! Failure
 	{
 		ultra_undo_needed = 1;
+		! Delete any leftover undo files from earlier sessions.
+		Ultra_Undo_Delete_All();
 		rfalse;
 	}
 	if ( res == -1 ) ! Success
@@ -29,6 +31,8 @@ Global ultra_undo_needed = 0;
 	if ( res == 1 ) ! Failure
 	{
 		ultra_undo_needed = 1;
+		! Delete any leftover undo files from earlier sessions.
+		Ultra_Undo_Delete_All();
 		rfalse;
 	}
 ];
@@ -111,8 +115,6 @@ Global ultra_undo_needed = 0;
 	}
 	glk_stream_close( gg_savestr, 0 ); ! stream_close
 	gg_savestr = 0;
-	! Delete an old save file
-	Ultra_Undo_Delete( ultra_undo_counter - ULTRA_UNDO_MAX_COUNT );
 	if ( res == 0 ) return 1;
 	.SFailed;
 	ultra_undo_counter--;
@@ -125,10 +127,11 @@ Global ultra_undo_needed = 0;
 	{
 		print (char) UUID_ARRAY->ix;
 	}
-	print "-", ultra_undo_counter;
+	print "-", (( ultra_undo_counter - 1 )  % ULTRA_UNDO_MAX_COUNT ) + 1;
+	! Translate ultra_undo_counter into a number between 1 and ULTRA_UNDO_MAX_COUNT
 ];
 
-[ Ultra_Undo_Delete val	fref exists;
+[ Ultra_Undo_Delete val fref exists;
 	@push ultra_undo_counter;
 	ultra_undo_counter = val;
 	fref = glk_fileref_create_by_name( fileusage_SavedGame + fileusage_BinaryMode, Glulx_ChangeAnyToCString( Ultra_Undo_Filename ), 0 );
@@ -148,12 +151,13 @@ Global ultra_undo_needed = 0;
 	}
 ];
 
-[ Ultra_Undo_Delete_All;
-	while ( ultra_undo_counter > 0 )
+[ Ultra_Undo_Delete_All ix;
+	for (ix=1 : ix <= ULTRA_UNDO_MAX_COUNT : ix++)
 	{
-		Ultra_Undo_Delete( ultra_undo_counter );
-		ultra_undo_counter--;
+		Ultra_Undo_Delete( ix );
+
 	}
+	ultra_undo_counter = 0;
 ];
 
 -) instead of "Undo" in "Glulx.i6t".

--- a/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
+++ b/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
@@ -14,12 +14,13 @@ Global ultra_undo_needed = 0;
 
 ! Test if the VM is able to perform an undo. This is necessary because Git won't tell us that it can't.
 [ Ultra_Undo_Test res;
+	! Delete any leftover undo files from earlier sessions.
+	Ultra_Undo_Delete_All();
+	
 	@saveundo res;
 	if ( res == 1 ) ! Failure
 	{
 		ultra_undo_needed = 1;
-		! Delete any leftover undo files from earlier sessions.
-		Ultra_Undo_Delete_All();
 		rfalse;
 	}
 	if ( res == -1 ) ! Success
@@ -31,8 +32,6 @@ Global ultra_undo_needed = 0;
 	if ( res == 1 ) ! Failure
 	{
 		ultra_undo_needed = 1;
-		! Delete any leftover undo files from earlier sessions.
-		Ultra_Undo_Delete_All();
 		rfalse;
 	}
 ];

--- a/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
+++ b/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
@@ -126,8 +126,8 @@ Global ultra_undo_needed = 0;
 	{
 		print (char) UUID_ARRAY->ix;
 	}
-	print "-", (( ultra_undo_counter - 1 )  % ULTRA_UNDO_MAX_COUNT ) + 1;
-	! Translate ultra_undo_counter into a number between 1 and ULTRA_UNDO_MAX_COUNT
+	! Take the mod of ultra_undo_counter to keep the number of files to ULTRA_UNDO_MAX_COUNT
+	print "-", ( ultra_undo_counter % ULTRA_UNDO_MAX_COUNT );
 ];
 
 [ Ultra_Undo_Delete val fref exists;

--- a/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
+++ b/Counterfeit Monkey Materials/Extensions/Dannii Willis/Ultra Undo.i7x
@@ -87,7 +87,7 @@ Global ultra_undo_needed = 0;
 	glk_stream_close( gg_savestr, 0 );
 	gg_savestr = 0;
 	.RFailed;
-	ultra_undo_counter = 0;
+	Ultra_Undo_Delete_All();
 	return 0;
 ];
 

--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -258,7 +258,7 @@ Chapter 3 - Undo Handling
 
 Ultra Undo is an extension kindly written by Dannii Willis to use external file recording to ensure that UNDO remains available.]
 
-Include version 1/140320 of Ultra Undo by Dannii Willis.
+Include version 1/160429 of Ultra Undo by Dannii Willis.
 
 	
 Part 2 - Multimedia


### PR DESCRIPTION
Maybe this isn't much of an improvement, but it has a couple of advantages. Instead of incrementing the filename of each new undo file, it rolls back to 1 when it goes past the ULTRA_UNDO_MAX_COUNT (default 10). This limits the number of files that might get left behind, and makes it easy to delete all of them.

Now all undo files are removed whenever the Ultra_Undo_Test fails. I'm not sure if that is the best place to do this or whether it is even necessary.

Please take a look and let me know what you think.

