### PR TITLE
Don't look up when typing UP

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -2798,7 +2798,10 @@ Instead of going nowhere when the noun is fronted by a facade (called blockage) 
 	carry out the listing exits activity.
 
 Instead of going nowhere when the noun is not fronted by a facade in the location:
-	try facing the noun;
+	if the noun is up:
+		say "There is no way up from here.[paragraph break]";
+	otherwise:
+		try facing the noun;
 	carry out the listing exits activity.
 
 A down-staircase is a kind of facade. Understand "step" or "steps" or "stairs" or "stairwell" or "staircase" as a down-staircase. A down-staircase is usually scenery.

--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -2799,7 +2799,7 @@ Instead of going nowhere when the noun is fronted by a facade (called blockage) 
 
 Instead of going nowhere when the noun is not fronted by a facade in the location:
 	if the noun is up:
-		say "There is no way up from here.[paragraph break]";
+		say "There is no way up.[paragraph break]";
 	otherwise:
 		try facing the noun;
 	carry out the listing exits activity.


### PR DESCRIPTION
When trying to walk in a direction that has no exit, Counterfeit Monkey will usually translate this as "FACE [direction]".

```
>d
We can't see anything interesting in that direction.
```

I'm usually fine with that, but for some reason it feels like a bug when I try to go up and get:

`The sun is so bright that it's hard to look straight up for long.`

So this PR changes the response of UP to "There is no way up" while keeping the "facing" responses of the other directions.

```
>u
There is no way up from here.
 
We can go north from here.
```

What do you think? Too inconsistent? Do you prefer it the old way?