### PR TITLE
Add back mild and obscene swearing like in the original version.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Viewpoint and Narrative Voice.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Viewpoint and Narrative Voice.i7x
@@ -52,7 +52,6 @@ the teach taking rule response (A) is "[first custom style]You can pick things u
 The teach inventory rule response (A) is "[first custom style]There's more we can do than just looking around. To check what you're holding at the moment, try typing INVENTORY, or I for short.[run paragraph on]".
 The teach meta-features rule response (A) is "[first custom style]To save your current position, type SAVE. RESTORE allows you to bring back a game you have previously saved.[run paragraph on]".
 
-[TODO: Add back swearing and singing?]
 The standard report taking rule response (A) is "[We] [one of]take[or]get[or]pick up[or]acquire[as decreasingly likely outcomes] [the noun][if the noun is unexamined and the action is singular]. [run paragraph on][noun description][no line break][otherwise].[end if]".
 The standard implicit taking rule response (A) is "[if the noun is unexamined and the action is singular][We] [one of]take[or]get[or]pick up[or]acquire[as decreasingly likely outcomes] [the noun]. [noun description][paragraph break][otherwise](first taking [the noun])[command clarification break][end if]".
 The standard report dropping rule response (A) is "[We] put down [the noun]."
@@ -82,6 +81,11 @@ The block burning rule response (A) is "[We] don't have a flame source, and if [
 
 To say nerve-damage:
 	say "[one of]I don't see that being a big help[or]I'd rather not, thanks[or]You're a strikingly tactile person, you know? But I don't see any purpose in it[or]Hm. Don't take this the wrong way, but do you think your need for haptic feedback is a sign of nerve damage during our synthesis? No? Okay, just checking[cycling]".
+
+Understand "bother" or "curses" or "drat" or "darn" as a mistake ("No kidding.").
+
+Understand "shit" or "fuck" or "damn" as a mistake ("Hey, calm down.").
+
 
 Section 2 - Making TRD first plural
 


### PR DESCRIPTION
This adds back the swearing functionality of the old version, but I'm not actually sure if it is an improvement. Without it, the Smarter Parser extension will handle swearing like this:

```
>damn
I'm sorry if you're feeling frustrated. If you like, you can type SAVE to store your progress to a file (in most interpreters), then RESTORE to come back to it later. In the meantime, you might try searching the web to see if there are hints available.
```

And with this change:

```
>damn
Hey, calm down.
```
