### PR TITLE
Add warnings and clarifications to all modified extensions.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Aaron Reed/Smarter Parser.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Aaron Reed/Smarter Parser.i7x
@@ -1,6 +1,8 @@
-Version 6 of Smarter Parser (for Glulx only) by Aaron Reed begins here.
+Version 6/160613 of Smarter Parser (for Glulx only) by Aaron Reed begins here.
 
 "Understands a broader range of input than the standard parser, and can direct new players towards proper syntax."
+
+[ WARNING: This is an updated version 6 for use with the 6M62 port of Counterfeit Monkey. For all other purposes version 16 or later is likely to be better - Petter Sjölund ]
 
 [
 CHANGES:

--- a/Counterfeit Monkey.materials/Extensions/Andrew Plotkin/Large Game Speedup.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Andrew Plotkin/Large Game Speedup.i7x
@@ -1,6 +1,9 @@
-Version 4/140731 of Large Game Speedup by Andrew Plotkin begins here.
+Version 5/160614 of Large Game Speedup by Andrew Plotkin begins here.
 
 "Performance improvements for games with several hundred objects."
+
+[ This version updated to work with the Inform 6M62 port of Counterfeit Monkey. Not very well tested - Petter Sjölund ]
+
 
 Use authorial modesty.
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Computers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Computers.i7x
@@ -1,8 +1,8 @@
-Version 7 of Computers by Emily Short begins here.
+Version 8/160611 of Computers by Emily Short begins here.
 
 "Computer hardware and software, including search engines and email programs. Version 3 adds handling for batteries and cords, if we include Power Sources by Emily Short (which itself depends on Plugs and Sockets by Sean Turner)."
 
-[CM version: changed out of bounds to out-of-bounds]
+[Version 8 updates for compatibility with the 6M62 port of Counterfeit Monkey. Changed out of bounds to out-of-bounds and password lock program to password-lock program. Removed deprecated features - Petter Sjölund]
 
 [Version 7 updates for compatibility with adaptive responses.]
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Facial Expressions.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Facial Expressions.i7x
@@ -1,4 +1,6 @@
-Facial Expressions by Emily Short begins here.
+Version 2/160611 of Facial Expressions by Emily Short begins here.
+
+[ Updated to work with the Inform 6M62 port of Counterfeit Monkey - Petter Sjölund ]
 
 Section 1 - Standard Gestures
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Facing.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Facing.i7x
@@ -218,7 +218,7 @@ Version 9 updates for 6E59, removing deprecated features. It also removes a numb
 
 Version 10 updates for adaptive text and responses.
 
-[Version 11/160611 Counterfeit Monkey version. Updated to work alongside Locksmith]
+Version 11/160611 Small fix to make it work alongside Locksmith by Emily Short - Petter Sjölund
 
 Example: * Directions and Doors - Allowing the player and his sidekick Clark to see into various rooms.
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Room Description Control.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Room Description Control.i7x
@@ -254,4 +254,4 @@ Version 10 removes deprecated phrases.
 
 Version 12 does some cleanup and brings the extension in line with adaptive responses.
 
-Version 13/160517: Update to work with Inform 6M62. Remove dependency on Plurality.
+Version 13/160517: Update to work with Counterfeit Monkey on 6M62. Remove dependency on Plurality - Petter Sjölund

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Tailored Room Description.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Tailored Room Description.i7x
@@ -423,7 +423,7 @@ The purpose of this change is to make the extension more flexible and more usefu
 
 Version 8 tweaks the reporting of character possessions and worn items to appear more natural. It also adds section headings to the documentation.
 
-Version 13/160601: Counterfeit Monkey version. Update for Inform 6M62. Fix tests. Remove dependency on Plurality.
+Version 13/160601: Counterfeit Monkey version. Update for Inform 6M62. Fix tests. Remove dependency on Plurality and deprecated features - Petter Sjölund
 
 
 Example: * Doors and doors - Writing paragraphs about doors to generate sentences such as "Exits include the white door and the black door. The black door is open."

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Actions.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Actions.i7x
@@ -1,8 +1,10 @@
-Threaded Actions by Emily Short begins here.
+Version 2/160611 of Threaded Actions by Emily Short begins here.
+
+[ Updated to work with the Inform 6M62 port of Counterfeit Monkey. Not tested with anything else - Petter Sjölund ]
 
 Section 1 - Main Elements
 
-[Include Threaded Conversation by Chris Conley.]
+Include Threaded Conversation by Emily Short.
 
 A stolen action is a kind of performative quip. The specification of a stolen action is "Any performative quip that is used to redirect the behavior of a standard command like KISS FRED or ATTACK CAT."
 	
@@ -224,6 +226,7 @@ Rule for refusing to attack someone when using conversation building option (thi
 		write " is an offensive quip." after file "NewConversation";
 		if nominal-sample-quip is switched on, escape troubled quip-names;
 		fill in standard quip.
+
 
 Example: * Produce Man - A simple example of reactions to shown objects.
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Conversation.i7x
@@ -2,7 +2,8 @@ Version 2/160606 of Threaded Conversation by Emily Short begins here.
 
 "A conversation system tracking facts known, phrases spoken, and subjects of conversation."
 
-"modified from Threaded Conversation by Emily Short and based on Alabaster by Emily Short, et. al."
+[ WARNING: This beta version is updated to work with the Inform 6M62 port of Counterfeit Monkey. For any other purpose, the latest version of Threaded Conversation by Chris Conley is likely to be better - Petter Sjölund ]
+["modified from Threaded Conversation by Emily Short and based on Alabaster by Emily Short, et. al."]
 
 Include Basic Screen Effects by Emily Short. 
 Include Complex Listing by Emily Short.

--- a/Counterfeit Monkey.materials/Extensions/Jim Aikin/Notepad.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Jim Aikin/Notepad.i7x
@@ -1,6 +1,6 @@
 Version 4/160517 of Notepad by Jim Aikin begins here.
 
-[Updated allowed pens to be relation for Counterfeit Monkey, everything else broken - Petter Sjölund]
+[ Updated allowed pens to be a relation in order to make it work with the 6M62 port of Counterfeit Monkey. Other functionality not tested - Petter Sjölund ]
 
 "A system for creating an in-game notepad that the player can write on."
 

--- a/Counterfeit Monkey.materials/Extensions/Jon Ingold/Far Away.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Jon Ingold/Far Away.i7x
@@ -2,6 +2,8 @@ Version 5/160517 of Far away by Jon Ingold begins here.
 
 "Creates an adjective for far-off items which cannot be touched."
 
+[ Updated to work with the Inform 6M62 port of Counterfeit Monkey. Removed deprecated features - Petter Sjölund ]
+
 Use far away extension translates as (- Constant FARAWAY; -).  
 Use far away extension.
 

--- a/Counterfeit Monkey.materials/Extensions/Mike Ciul/Scope Caching.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Mike Ciul/Scope Caching.i7x
@@ -1,10 +1,12 @@
-Version 2/120725 of Scope Caching by Mike Ciul begins here.
+Version 3/160611 of Scope Caching by Mike Ciul begins here.
 
 "Gives things the 'marked-visible' property, to check the visibility of something without repeating the entire scope loop each time. Works with Epistemology by Eric Eve, Conditional Backdrops by Mike Ciul, and Remembering by Aaron Reed."
 
 "based on code provided by Andrew Plotkin"
 
 [and Jimmy Maher? http://www.intfiction.org/forum/viewtopic.php?f=7&t=3241&start=40]
+
+[ Updated to work with the Inform 6M62 port of Counterfeit Monkey. Not tested with Epistemology or Remembering - Petter Sjölund ]
 
 Use authorial modesty.
 


### PR DESCRIPTION
I have no idea what the proper way to do this is, but I've tried to add comments and warnings to all modified extensions. This is to remind myself which ones I've actually modified and how, and also in the unlikely case that somebody downloads these and tries to use them with their own projects. 

I've added my own name in order to emphasize that these are not official releases by the original authors.
