### PR TITLE
Give actions applying to things precedence over actions applying to rooms.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
@@ -63,10 +63,6 @@ Instead of smelling Arbot Antiques:
 The maps collection is a thing in Arbot Maps & Antiques. Understand "large" or "collection" or "of" or "antique" or "under glass" or "street maps" or "maiana" or "navigation" or "distant places" or "charts" or "island" or  "topography" as the maps collection. It is fixed in place. The printed name is "[if looking]collection[otherwise]maps collection[end if]". The initial appearance is "There is a large [maps collection] of vintage and antique maps under glass [--] the island of Atlantis as a whole, street maps of here and of Maiana, navigation maps of the harb[our], and then maps of more distant places as well."
 	The description of the maps collection is "[We] pore over a map of [one of]the Old City when the walls were still intact, as reconstructed from archaeological surveys[or]forbidden dig zones in Atlantis[or]bus routes between here and Maiana ca. 1973[or]island topography as measured in 1910[or]1880 shipping lines between Atlantis, Gibraltar, and points east[at random]."
 
-Before local looking Arbot Maps & Antiques:
-	if the player's command does not include "arbot/&" and the player's command includes "maps":
-		try examining the maps collection instead.
-
 Instead of examining the maps collection when the Slangovia map is unseen:
 	move the Slangovia map to the location;
 	say "[We] study the maps. One in the collection stands out: a [Slangovia map], framed like all the others but of suspiciously recent vintage."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -151,9 +151,9 @@ Carry out letter-removing the topic understood from something:
 	try tuning the letter-remover to the topic understood;
 	try waving the letter-remover at the second noun.
 
-Understand "wave [something preferably held] at/toward/over/around/on/across [something]" as waving it at. Waving it at is an action applying to one carried thing and one visible thing.
+Understand "wave [something preferably held] at/toward/over/around/on/across [thing]" as waving it at. Waving it at is an action applying to one carried thing and one visible thing.
 
-Understand "use [letter-remover] on [something]" as waving it at. Understand "point [letter-remover] at [something]" as waving it at.
+Understand "use [letter-remover] on [thing]" as waving it at. Understand "point [letter-remover] at [thing]" as waving it at.
 
 Understand "wave [something preferably held] at/toward/over/around [any locally-present room]" as waving it at.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -794,6 +794,8 @@ Definition: a room is locally-present if it is the location.
 
 Understand "here" or "surroundings" as a room when the item described is the location.
 
+Understand "examine [thing]" or "look [thing]" or "look at [thing]" as examining.
+
 Understand "examine [any locally-present room]" or "look at [any locally-present room]" or "look [any locally-present room]" as local looking. Understand "look around" as looking.
 
 Local looking is an action applying to one thing.


### PR DESCRIPTION
As discussed in #27, here are some new grammar lines that use [thing] instead of [something] in order for the parser to consider them before grammar lines with [any locally-present room].