### PR TITLE
Remove yourself from drop all-lists

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -341,6 +341,11 @@ A multiple action processing rule when dropping:
 	if the player is empty:
 		alter the multiple object list to {};
 		say "[We] don't have anything to drop.";
+	otherwise:
+		let L be the multiple object list;
+		if the player is listed in L:
+			remove player from L;
+			alter the multiple object list to L.
 
 The new exclude people from drop all rule is listed instead of the exclude people from drop all rule in the for deciding whether all includes rulebook.
 


### PR DESCRIPTION
Sometimes you would try to drop yourself while dropping all. This was caused by the code that removes the "What do you want to drop those things in?" message that appears when you type DROP ALL while carrying nothing.