### PR TITLE
Going in and going out, looking in and looking out

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -150,6 +150,7 @@ Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 		•	Section 6 - The THINK verb ]
 	
 Include World Model Tweaks by Counterfeit Monkey.
+Include Insides and Outsides by Counterfeit Monkey.
 Include Actions on Multiple Objects by Counterfeit Monkey.
 
 [	•	Book 4 - Default World Model Tweaks
@@ -544,7 +545,8 @@ Include Presentation Details by Counterfeit Monkey.
 Include Character Models by Counterfeit Monkey.
 Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 Include World Model Tweaks by Counterfeit Monkey.
-Include Actions on Multiple Objects by Counterfeit Monkey.
+Include Insides and Outsides by Counterfeit Monkey
+Include Actions on Multiple Objects by Counterfeit Monkey..
 Include Features of Created Objects by Counterfeit Monkey.
 Include Schedule and Time by Counterfeit Monkey.
 Include Act I Among Sightseers by Counterfeit Monkey.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -132,6 +132,8 @@ Carry out going through the temporary barrier:
 
 Ampersand Bend is south of the temporary barrier. It is a road. The description is "A bend in the street, which runs west and north. This district combines the old and the new: a small [museum] in an ancient stone building to the east, a shiny [real estate office] south. The window of the museum is currently displaying one of its exhibits, [a list of things *in the display stand][if the code is on the display stand]. Well, not to worry: they'll be able to restore the codex easily enough when the museum reopens[end if]." Understand "district" as Ampersand Bend.
 
+Out-direction of Ampersand Bend is north. [Through the barrier]
+
 Instead of listening to Ampersand Bend:
 	say "The sounds from the north suggest a holiday fair in full swing: children laughing and shouting, people selling food and drinks, various fairground machinery, tinny music."
 
@@ -1057,9 +1059,6 @@ Rule for listing exits when the location is Church Forecourt:
 
 The cinema-exterior is a facade in Church Forecourt. It fronts north. It is scenery. The description is "Large red letters on the marquee announce the latest film from Cannes." Understand "small" or "cinema" or "theater" or "theatre" or "movie" or "red letters" or "large red" or "large letters" or "large red letters" or "marquee"  or "film" or "cannes" as the cinema-exterior. The printed name is "cinema".
 
-Instead of going inside when location is Church Forecourt:
-	try going west.
-
 Section 4 - Heritage Corner
 
 The Heritage Corner is east of the Fair and southeast of Park Center. It is proper-named. The description is "This patch of the town square has been paved over in [octagonal bricks] and is commonly used for displays of traditional dancing: over-50 women in home-made embroidered aprons, skipping arm-in-arm and jumping over broomsticks[one of].
@@ -1068,6 +1067,8 @@ No, there aren't any here [i]now[/i]. But trust me. It's an unforgettable sight[
 
 Rule for distantly describing Heritage Corner:
 	say "That way is the bricked-over portion of the town square, sometimes used for exhibitions of regional dance. Today it is less populated than most of the Square[if the location is the Fair]. Beyond Heritage Corner to the east is the hostel where you stowed some important gear[end if]."
+
+In-direction of Heritage Corner is east. [Into the hostel]
 
 A diorama table is fixed in place in Heritage Corner. It is a supporter. The initial appearance is "Under a bit of [diorama-shelter] in the corner, [a diorama table] shows scenes from local history, rotated out each week. This week's diorama represents the first sitting of the Committee for the New Orthodox Orthography." Understand "diorama" or "scene" or "dioramas" or "shelter" or "scenes" or "local history" or "history" as the diorama table.
 
@@ -1148,13 +1149,9 @@ Instead of examining the octagonal bricks:
 	otherwise:
 		continue the action.
 
-Instead of going inside when the location is Heritage Corner:
-	try going east.
-
 Chapter 2 - Indoor Areas
 
 Section 1 - Cinema
-
 
 The Cinema Lobby is north of Church Forecourt. It is indoors. The description is "This is a small, one-screen theater. [one of]The seats are not comfortable and the screen is not large. The projector is old. The management is lazy. No food is served.
 
@@ -1164,8 +1161,8 @@ Despite these handicaps, it maintains an active and interested clientele simply 
 
 [or][stopping]Evidently the next showing is not for a little while yet, because there are no patrons in sight."
 
-Instead of going inside when the location is Cinema Lobby:
-	try going west.
+In-direction of Cinema Lobby is west. [Into screening room]
+Out-direction of Cinema Lobby is south. [To church forecourt]
 
 Rule for listing exits when the location is Cinema Lobby:
 	if looking, do nothing;
@@ -1190,6 +1187,8 @@ Instead of going to the Screening Room when the ticket-taker does not know allow
 	queue hang-on-there.
 
 The Screening Room is west of Cinema Lobby. It is indoors. The description is "[if the player recollects what the movie seems]'Red'[otherwise]Whatever is scheduled for later showing[end if] has not started yet, and is probably not destined to start for some time; at any rate,[unless the project is switched on] the [film screen] is blank and[end if] no audience has yet assembled."
+
+Out-direction of Screening Room is east. [Back to cinema lobby]
 
 Instead of waiting in the Screening Room:
 	if the reel is in the projector and the projector-switch is switched on:
@@ -1444,13 +1443,14 @@ Section 3 - The Hostel
 
 The Hostel is east of Heritage Corner. It is indoors. The description is "I take it this is where you stayed from the time you got to town until our operation. I would have expected that someone with your credentials would have been able to afford something better: The Fleur d'Or, maybe? But maybe you thought this was lower-profile. At least it's clean and doesn't smell funny."
 
-Instead of exiting in the Hostel, try going west.
-
 Rule for listing exits when the location is the Hostel:
 	if looking, say "There's a [h-staircase] that leads up to the dormitory rooms.";
 	otherwise say "[We] could either climb the [h-staircase] up to the dormitory rooms or go back to the park, [west]."
 
 The h-staircase is an up-staircase. The h-staircase is in the Hostel. The printed name is "spiral staircase". Understand "spiral" or "staircase" as the h-staircase. It fronts up. The description is "To save space, it winds around a pole twice before reaching the floor above. This is not kind to people with luggage, but people with luggage are supposed to stay in real hotels."
+
+In-direction of the hostel is up. [Into the dormitory]
+Out-direction of the hostel is west. [Back out to Heritage Corner]
 
 Instead of facing up in the hostel:
 	say "The ceiling is a little cracked but in no way fascinating."
@@ -1855,6 +1855,8 @@ The gift shop volunteer wears a knitted wool cap. The description of the knitted
 
 The Church Garden is west of New Church. The description is "One might expect a graveyard, but burial inside the city walls has been forbidden for sanitation reasons since well before the New Church was built. Instead, there is a small meditation garden, which was once designed as an intricate knotwork of shrubs[if the thicket is not in the location]. Now the shrubs are gone[end if]."
 
+In-direction of Church Garden is east. [Back into the church]
+
 Report facing in Church Garden:
 	say "The garden is intentionally a space set apart, from which it is hard to see anything of the rest of the world." instead.
 
@@ -1973,6 +1975,8 @@ Rule for listing exits when the location is Roundabout:
 [Procedural rule when listing exits:
 	if the location is Roundabout, ignore the append room names rule.]
 
+In-direction of Roundabout is inside. [In from the roundabout is the traffic circle]
+
 Understand "change lanes" as a mistake ("Oh, please don't, please don't...") when the player is in a car.
 
 Understand "yield" as a mistake ("It's hard to go wrong with that, anyway.") when the player is in a car.
@@ -2030,11 +2034,15 @@ Instead of putting the restoration gel on the defaced ashlar block:
 Rule for listing exits when looking in Old City Walls:
 	do nothing instead.
 
+In-direction of Old City Walls is east. [Into the old hexagonal turret]
+
 Turret-view is a facade in Old City Walls. It fronts east. It is scenery. The printed name is "turret". Understand "old" or "hexagonal" or "tower" or "turret" as turret-view. The description is "The turret extends to the east. It's one of the best preserved pieces of the old wall."
 
 Section 2 - The Turret
 
 The Old Hexagonal Turret is east of Old City Walls. The description is "Up here [we] stand on the remains of the old fortifications; this turret offers a view out over the docks, the fish market, and the harbor, which it was designed to protect."
+
+Out-direction of Old Hexagonal Turret is west. [Back to old city walls]
 
 The depluralizing cannon is a container in the Old Hexagonal Turret. It is fixed in place. Understand "heavy" or "old" or "barrel" as the depluralizing cannon. The printed name is "deplural[izing] cannon".
 	The initial appearance is "A heavy old [depluralizing cannon] is aimed out to sea."
@@ -2164,6 +2172,8 @@ A description-concealing rule:
 Section 2 - Webster Court
 
 Webster Court is north of Hesychius Street and west of Crumbling Wall Face. The description is "[if former direction is north]Hesychius Street opens here into a broad and plainly-paved court[otherwise if former direction is west]Here below the wall is a broad, plainly-paved court[otherwise]A broad and plainly-paved court[end if][unless statue of Noah Webster is as-yet-unknown], named for [the statue of Noah Webster][end if]."
+
+In-direction of Webster Court is north. [Into my parent's house]
 
 Instead of facing west in Webster Court:
 	say "The old city wall cuts off any view towards the harbor and the far horizon. The taller houses permit a view over, however."
@@ -2338,6 +2348,8 @@ Roget Close is west of Webster Court. The description is "A pleasantly sheltered
 [Instead of looking in Roget Close when Private Beach is visited and lexicon-tick is 0:
 	do nothing instead.]
 
+In-direction of Roget Close is north. [Through the spinner gate]
+
 Instead of going west in Roget Close:
 	say "School is out for the holiday. [run paragraph on]";
 	carry out the listing exits activity.
@@ -2390,6 +2402,8 @@ Section 5 - Winding Footpath
 The spinner-gate is north of Roget Close.  It is a closed transparent locked door. The printed name of the spinner-gate is "gate". Understand "gate" as the spinner-gate. The initial appearance is "If you look just north between the houses, you'll notice also the footpath down to an almost-private beach. It used to be open, but it's now gated off, and built into the [spinner-gate] is a chic modern sculpture."
 
 The description of the spinner-gate is "A gate of wrought iron bars between two sturdy columns[if the spinner-gate is closed and the spinner-gate is locked], too close to climb through and too tall to climb over[else if the spinner-gate is closed], closed but not locked[else if the spinner-gate is open]; at the moment the gate has been pushed conveniently open[end if]. Built into the right-hand column, next to the gate latch, is a curious sculpture."
+
+Out-direction of Winding Footpath is south. [Through the spinner gate]
 
 Through spinner-gate is the Winding Footpath. South of Winding Footpath is Roget Close.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
@@ -106,6 +106,8 @@ The aquarium-shelving is scenery in the aquarium. Understand "shelves" or "books
 
 The collection of fish is scenery in the Aquarium. Understand "swordfish" or "bass" as the collection of fish. The description is "None of the fish has been dusted in the last decade. The collection presents a slightly mournful air."
 
+Out-direction of Aquarium Bookstore is west. [Deep Street]
+
 Understand "browse [merchandise]" as searching.
 
 Test merch with "browse / browse merchandise / x merchandise / look at merchandise / g / g / g" in Aquarium bookstore.
@@ -215,6 +217,8 @@ The Fish Market is northwest of Deep Street. The description is "Not very fishy 
 Rule for listing exits when the location is Fish Market and the Authenticator is in the location:
 	do nothing instead.
 
+In-direction of Fish Market is east. [Tin hut]
+
 After going to Fish Market when the authenticator is in Fish Market and the player is hurrying:
 	let N be the number of entries in the path so far of the player;
 	if N is greater than 1:
@@ -252,6 +256,8 @@ Sanity-check doing something in the presence of the Authenticator:
 	if looking:
 		make no decision;
 	otherwise if going east:
+		make no decision;
+	otherwise if going inside:
 		make no decision;
 	otherwise if approaching the tin hut:
 		make no decision;
@@ -292,6 +298,8 @@ The Outdoor Cafe is south of the Fish Market and west of Deep Street. The printe
 
 The rocky cliff-face is a scenery facade in Outdoor Cafe. It fronts south. Understand "cliff" or "rocks" or "face" as the rocky cliff-face. The description is "This little terrace area has been carved out of the hillside. Immediately to the south there is only rough rock wall for many feet up."
 	The closure notice is "That way is bare cliff rock. ".
+
+In-direction of Outdoor Cafe is west. [Into the café building (facade)]
 
 The cafe building is a scenery facade in Outdoor Cafe. It fronts west. The printed name is "café building". Understand "café" as the cafe building. The description is "The source of drinks and small snacks when the café is in full operation. At the moment there isn't much sign of life from inside." The closure notice of the cafe building is "[if traffic circle is visited]The place is entirely closed now.[else]When we approach, a girl comes to the window and waves us off. 'We're just closing up. No new customers!'[end if] "
 
@@ -372,6 +380,9 @@ Section 6 - Tin Hut
 
 The Tin Hut is east of the Fish Market. It is indoors. The description is "Most of the light in here comes from [circular windows] punched into the tin walls just under the ceiling. From the inside, the building looks both larger and more sound than it appears from outside: there are plenty of sturdy [struts] supporting the roof and keeping the walls upright."
 	The introduction is "Sometimes smugglers and forgers have been known to stash things in here, since the building is close to the docks but rarely attracts the interest of customs officials."
+
+Out-direction of Tin Hut is west. [Out to fish market]
+In-direction of Tin Hut is down. [Into the crawlspace]
 
 Understand "hide [text]" as a mistake ("A natural impulse, but I don't think she's coming in here. And if she did, the last thing [we][']d want would be to be caught hiding. The key thing is to be in plain sight and obviously innocent.") when the location is the Tin Hut and the Authenticator is in the Fish Market.
 
@@ -466,6 +477,8 @@ Section 7 - The Crawlspace
 
 The Crawlspace is below the trap-door. The description is "An awkward, low, concrete-lined crawlspace beneath the tin hut. It smells somewhat like animals; in spite of this it clearly gets a bit more use than anyone would like the customs officials to know about."
 
+Out-direction of Crawlspace is up. [Into the tin hut]
+
 The Crawlspace is indoors.
 
 After deciding the scope of the player when the player is in the Crawlspace:
@@ -559,6 +572,8 @@ Section 9 - Counterfeit Monkey
 
 The Counterfeit Monkey is west of the Docks. It is proper-named and indoors. The description is "[one of]It takes a minute for us to adjust to the light in here. [or]Infamously this pub was raided in 1929, the year that the Bureau developed its first meager attempt at an Authentication Scope, and dozens of smugglers and fraudulent businessmen went to jail. But neither that raid nor subsequent scrutiny has ever shut the place down entirely. [or][stopping]Built when people were a bit shorter and ceilings were a bit lower, the Counterfeit Monkey is always smoky and never well lit, even in the middle of the day."
 
+Out-direction of Counterfeit Monkey is east. [To the docks]
+
 A description-concealing rule when Slango is in the Counterfeit Monkey:
 	now the clientele is unmarked for listing;
 	now the barman is unmarked for listing.
@@ -649,6 +664,8 @@ The Customs House is east of the Docks. It is indoors. The description is "This 
 
 There is a [long line] of people waiting to leave Atlantis, even on Serial Comma Day."
 	The introduction is "No one is paying any attention to us [i]yet[/i], but I wouldn't advise spending much time here."
+
+Out-direction of Customs House is west. [To the docks]
 
 Sanity-check entering the long line:
 	say "We can only afford to try going through this line once, and it's going to have to be when we're really ready to leave. Which we're not." instead.
@@ -880,7 +897,8 @@ To say luggage-item:
 
 
 Sanity-check going nowhere when the location is Customs House:
-	try entering the long line instead.
+	unless the noun is outside:
+		try entering the long line instead.
 
 Test Customs with "tutorial off / look / x side rooms / x line / x tourists / x scientists / x officials / x private room / z / z / z / z / z / z" in Customs House.
 
@@ -952,7 +970,7 @@ Check waving the letter-remover at the Traffic Circle when the current setting o
 
 Traffic Circle is inside from the Roundabout. It is a privately-controlled outdoors road.
 
-[TODO:][test]
+Out-direction of Traffic Circle is outside. [The roundabout and the traffic circle are the only place where the standard outside and inside directions are used]
 
 The no-dropping rule does nothing when the current action is dropping the restoration-gel rifle and the location is Traffic Circle.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
@@ -22,9 +22,6 @@ Long Street North is a proper-named and southern road. The description is "Long 
 
 Some anemic palm trees are a backdrop. They are in Long Street North and Long Street South. The description is "The only foliage comes in a clump high above. The effect is distorted and unnatural, and I say that having lived with them all my life. They are trees in the same sense that ostriches are birds." The printed name is "an[ae]mic palm trees". Understand "palms" or "anaemic" as the anemic palm trees.
 
-Instead of going inside when location is Long Street North:
-	try going west.
-
 South of Long Street North is Long Street South. Long Street South is a  proper-named southern road. The description is "Long Street is lined on each side with a double-row of tall, an[ae]mic palm trees that bend towards one another many feet overhead. [We] are now in the southern part of this long corridor, between the Canadian Embassy and Arbot Maps & Antiques."
 
 The Canadian Embassy is a facade in Long Street South. It fronts east. It is scenery. The description is "The embassy is the largest foreign embassy here: Canadians do a lot of business with Atlantis, but the Québécois require special permission to enter, so there's a call for substantial clerical work. The building is a solid 1960s block in concrete with slit-shaped windows." Understand "concrete" or "windows" or "solid" or "block" or "slit-shaped" or "slit" or "window" or "slit shaped" or "slits" as the Canadian Embassy.
@@ -56,6 +53,8 @@ After going to Arbot Maps & Antiques:
 		move the player to Long Street South, without printing a room description.
 
 Arbot Maps & Antiques is west of Long Street South. It is indoors and southern. Understand "shop" or "store" or "antique" as Arbot Maps &  Antiques.
+
+Out-direction of Arbot Maps & Antiques is east. [Long Street South]
 
 Instead of smelling Arbot Antiques:
 	say "The place smells of fresh coffee and old paper."
@@ -139,6 +138,8 @@ If you are my mother, you call this style Atlantean Postmodern. Less kindly, it 
 Fleur d'Or lobby is indoors and southern. The room divider is a scenery thing in Fleur d'Or Lobby. The printed name is "sheet of frosted glass". Understand "glass" or "sheet" or "sheet of" or "frosted" or "annotation" or "primordial" or "primeval" or "sea" as the room divider. The description is "The glass is a good three quarters of an inch thick, and looks very sturdy. The etched letters glow or fade out again depending on the changing light conditions in the lobby.
 
 Annotation in the corner indicates that this is a commissioned artwork by Anne Landis Rosehip, entitled 'The Primeval Sea.'"
+
+Out-direction of Fleur d'Or Lobby is east. [To Long Street North]
 
 The spotlights are a scenery thing in the Fleur d'Or Lobby. Understand "spotlight" or "light" or "lights" or "lighting" or "changing light" or "pools" or "distinct pools" as the spotlights. The description is "The spotlights are more or less steady blue, just fluctuating a little in intensity to add to the sense of being underwater."
 
@@ -346,6 +347,8 @@ Section 2 - Babel Cafe
 
 South of Palm Square is Babel Café. Understand "cafe" as the Babel Café. The description of Babel Café is "Through many changes of management, this institution has fed the denizens of the university and ignored their semi-sedition." Babel Café is indoors and southern.
 
+Out-direction of Babel Café is north. [Back to Palm Square]
+
 The clerk is an alert man in the Babel Café. The initial appearance is "[A clerk] in [a white apron] stands behind [the long glass case][unless the long glass case contains something], now emptied by our purchases[end if]." The clerk wears a white apron.
 	The description of the clerk is "A smooth-faced young man. He has the cheery demean[our] of one earning substantial overtime pay."
 	The description of the white apron is "Clean white cotton, bordered with a Greek meander trim in dark blue embroidery thread."
@@ -478,7 +481,10 @@ Understand "climb through [something]" or "climb in [something]" or "climb into 
 
 Section 4 - Apartment Bathroom
 
-The Apartment Bathroom is north of My Apartment. The apartment bathroom is a southern bathroom.
+The Apartment Bathroom is north of My Apartment. The apartment bathroom is a bathroom. It is southern.
+
+In-direction of Apartment Bathroom is south. [My apartment]
+Out-direction of Apartment Bathroom is east. [Palm Square]
 
 Rule for listing exits when the location is Apartment Bathroom:
 	say "[We] could climb back out the window, or [we] could go south into the rest of my apartment."
@@ -521,6 +527,8 @@ My Apartment is a kitchen. It is southern. The introduction of my apartment is "
 
 Rule for listing exits when looking in My Apartment:
 	do nothing instead.
+
+Out-direction of My Apartment is northeast. [Palm Square]
 
 The kitchen area is fixed in place in My Apartment. The flexible appearance is "It's an efficiency: note [the kitchen area], with all the usual appliances, in one corner."
 
@@ -677,6 +685,9 @@ The sturdy iron gate is southeast of Palm Square. It is scenery. The sturdy iron
 
 I have the student ring that opens this back in my apartment. I just wasn't expecting to need to go in there ever again[ring-fetch][end if].".
 
+Out-direction of University Oval is northwest. [Palm Square]
+In-direction of University Oval is south. [Samuel Johnson Hall]
+
 After printing the name of the sturdy iron gate when Palm Square is not visited:
 	say " to the university".
 
@@ -758,6 +769,8 @@ That's to say that we study how the ability to change things based on their name
 [or][stopping]The department office, with several professorial offices leading off of it, is to the [southeast]. To the [southwest] is the seminar room, where many of the upper-level courses occur, and which also contains the department library; downstairs is the basement, where the graduate students and junior instructors are kept."
 
 Samuel Johnson Hall is indoors and southern.
+
+Out-direction of Samuel Johnson Hall is north. [To University oval]
 
 Rule for listing exits while looking in Samuel Johnson Hall:
 	do nothing instead.
@@ -1763,6 +1776,8 @@ The description of the worn leather jacket is "A moderately cool sort of bomber-
 Section 11 - Lecture Hall
 
 Lecture Hall 1 is east of Samuel Johnson Basement. The description is "The main lecture hall used for large survey courses in language studies offered to undergraduates. I sat through courses here when I was an undergraduate myself, and have now delivered a few lectures as a teaching assistant." Lecture Hall 1 is indoors and southern.
+
+Out-direction of Lecture Hall 1 is west. [Back to Samuel Johnson basement]
 
 After deciding the scope of the player when the location is Lecture Hall 1:
 	place the wooden seats in scope.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -115,6 +115,8 @@ The Public Convenience is east of Bus Station. It is indoors and southern. The P
 
 The introduction of the Public Convenience is "A faint smell of lavender lingers in the air."
 
+Out-direction of Public Convenience is west. [To the bus station]
+
 Some sink-collectives are scenery in the public convenience. The sink-collectives are privately-named. The printed name is "sinks".  Understand "sinks" as sink-collectives.
 
 Sanity-check doing something other than examining to the sink-collectives:
@@ -197,6 +199,8 @@ The Rotunda is south of Tall Street. It is indoors and southern. The description
 What sets this one apart is the lettering, each sigil no bigger than a flea, carved over every inch of the walls. Inscribed here is, in fact, the [italic type]entire[roman type] [inscribed-text] of A New Orthodox Orthography[if the Rotunda is unvisited], which means that if [we] had a great deal of patience and many rolls of butcher paper, [we] could take rubbings and wind up with our very own volume.
 
 [We] don't, of course. There are better things to do. More important places to go[end if]. The administrative part of the bureau is away to the south, and there is an exhibit of letter tools to the east, which is open to the public."
+
+Out-direction of Rotunda is north. [To Tall Street]
 
 Instead of facing up in the Rotunda: try examining the inscribed-text.
 
@@ -329,6 +333,9 @@ Section 7 - Antechamber
 The Antechamber is south of the Rotunda. It is indoors and southern. The description is "The most important task of any government bureau is to keep away time-wasters, irritants, and uninformed members of the general public, who might distract the diligent workers within from their important tasks. The Bureau of Orthography is no different.
 
 An [instructive notice] details the criteria for entry to the Bureau proper."
+
+Out-direction of Antechamber is north. [To the rotunda]
+In-direction of Antechamber is east. [To Bureau hallway]
 
 The instructive notice is scenery in the Antechamber. The description is "Please note that those wishing to enter must have a PASS suitable for visitors, which must include an UP TO DATE photograph closely resembling the subject. Passes that do not look like their possessors will be rejected.
 
@@ -512,7 +519,7 @@ Section 8 - Hallway and Inaccessible Room
 
 The Bureau Hallway is east of the Antechamber. It is indoors and southern. The description is "This is a long hallway with many doors leading off, the business of the bureau being varied and all-encompassing; it is for all essential purposes the chief organ of government in Atlantis, since only a few topics are brought to citizen referendum."
 
-
+Out-direction of Bureau Hallway is west. [To antechamber]
 
 The All-Purpose Office is east of Bureau Hallway. It is indoors and southern. The description is "There's a front desk at which a receptionist meets with members of the public and assesses their needs; beyond that, the room is crowded with dozens of stations for the use of the All-Purpose Officers, and stretches back some distance. It looks like an old-fashioned newsroom.
 
@@ -528,6 +535,8 @@ Chapter 2 - Bureau Basement
 Section 1 - Foot of Stairs
 
 Below Bureau Hallway is Bureau Basement South. Bureau Basement South is indoors, forbidden and southern. The description of Bureau Basement South is "[We] have descended into a windowless underground passage. The hallway runs [north] from here, and for an eerily long way [--] the tunnels must extend well beyond the above-ground profile of the building."
+
+Out-direction of Bureau Basement South is up. [To bureau hallway]
 
 Rule for writing a paragraph about the plywood cutout when the seer automaton is mentionable and the location is Bureau Basement South:
 	say "Propped in the corner are some articles that were probably meant to be used as part of the Serial Comma Day Fair, but got confiscated instead: [a seer automaton] and [a plywood cutout] depicting Atlantida.".
@@ -644,6 +653,8 @@ Some Hello Kitty stickers are part of the cute security door. The description is
 Section 3 - Secret Section
 
 Bureau Basement Secret Section is indoors, forbidden and southern. The description is "The heightened security on this side of the door is obvious everywhere [we] look. The floor is tiled in paisley tiles. The light fixtures give off pale pink light. The walls are covered in frog leather. The doors are locked with padlocks the size of handbags, locks decorated à la Louis Quinze, combination locks made of solid gold. There is not a bare noun in sight."
+
+Out-direction of Bureau Basement Secret Section is south. [Bureau basement middle]
 
 Some frog leather walls, paisley tile floors, enormous padlocks, fancy locks, and gold combination locks are scenery in the Bureau Basement Secret Section. The description of the frog leather walls is "Mostly green spotted with brown, but for decorative trim they've used more exotic tree frogs in blue and orange."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
@@ -490,6 +490,8 @@ Section 5 - Tunnel through Chalk
 
 The Tunnel through Chalk is below Surveillance Room.  Tunnel through Chalk is indoors and forbidden. The description is "This passage has been cut through natural cliff rock and looks older than the Bureau itself. The walls are rough-hewn, exposing [sedimentary strata]. Here and there it looks as though someone has actually excavated a fav[our]ed rock or relic."
 
+In-direction of Tunnel through Chalk is east. [Personal apartment]
+
 The sedimentary strata are scenery in the Tunnel through Chalk. The description is "Layers of slightly varying chalk col[our], some of which are embedded with tiny seashells and other fossil evidence." Understand "layers" or "chalk" or "seashells" or "tiny" or "shells" or "evidence" or "fossil evidence" as the sedimentary strata.
 
 Every turn when the location is Tunnel through Chalk:
@@ -680,6 +682,8 @@ Section 2 - Private Solarium
 
 The Private Solarium is east of Personal Apartment. It is indoors and forbidden. It contains a coffee table and a chaise longue. The description of the coffee table is "Antique as well, most likely. It is the same handsome wood as the furnishings in the rest of the apartment."
 
+In-direction of Private Solarium is west. [Back to personal apartment]
+Out-direction of Private Solarium is north. [Out to precarious perch]
 
 Rule for listing exits when looking in the Private Solarium:
 	do nothing instead.
@@ -814,6 +818,8 @@ Report touching the sea-view:
 			say "The water retains the heat of a very sunny day, though the air is cooling quickly." instead;
 
 Precarious Perch is a room. It is forbidden. The description is "From up here there's a handsome [distant-sea-view], which isn't [i]so[/i] far down [i]really[/i]. But it's a scramble down a nearly sheer cliff for the first bit, until [we] make it down to the rockfall below, and it would be easy for a careless person to injure herself."
+
+In-direction of Precarious Perch is south. [Back into private solarium]
 
 Rule for listing exits while looking in Precarious Perch:
 	do nothing instead.
@@ -1101,6 +1107,8 @@ The Navigation Area is fore from the Sunning Deck. It is nautical. The descripti
 
 The Galley is just below, [down] a steep staircase that is almost a ladder."
 
+In-direction of Navigation Area is down. [Into galley]
+
 Rule for writing a paragraph about Slango when Slango is on the Command Chair:
 	say "Slango is in [the command chair]. He looks more relaxed driving the boat than I've ever seen him before."
 
@@ -1113,6 +1121,8 @@ The command chair is an enterable scenery supporter in the Navigation Area. The 
 The controls are scenery in the Navigation Area. Understand "mass" or "buttons" or "button" or "lever" or "levers" or "steering" or "wheel" as the controls. The description is "It's curious, looking at these and knowing I've never touched them before in my life, and yet having your instinctive muscular knowledge of what they're all for and how they work. I feel like I could sit down and drive the yacht, and at the same time I find the idea terrifying."
 
 Foredeck is fore from the Navigation Area. It is nautical. The description is "Here the yacht is nothing but a nose over the water. A [hatch], hardly big enough for a portly person, descends into the so-called crew cabin."
+
+In-direction of Foredeck is down. [Into crew cabin]
 
 Some portholes are a kind of thing. Portholes are usually scenery. The description of the portholes is usually "Perhaps I should drop any attempt to sound nautical and just call them windows, because they are not the round things one normally thinks of. But they are waterproof and just above the water line."  Understand "window" or "windows" or "porthole" or "portholes" as portholes. The printed name of portholes is always "portholes".
 
@@ -1143,6 +1153,8 @@ The Crew Cabin is a room. It is nautical. It is indoors. The description is "It 
 
 I'm fascinated to note what shape a bed can be when it's not rectangular. More sort of curved and tapering. Convenient if you're called on to house a mermaid.".
 
+Out-direction of Crew Cabin is up. [Out to foredeck]
+
 Instead of looking in Crew Cabin when the player is gelled:
 	say "One upside to our continuing to share the same bodies: I don't have to try to sleep in that narrow tapery bed."
 
@@ -1155,6 +1167,8 @@ Section 5 - Galley
 The Galley is below the Navigation Area. It is nautical. It is indoors. The description is "Smaller than the kitchen in a comfortable house, but carefully and elegantly fitted, with an electric stovetop, a convection oven/microwave, a tiny refrigerator, a sink: enough, in short, to serve the crew of three on long trips.[one of] I guess even a fairly big boat is still small on the inside, eh?[or][stopping]
 
 There's even a little washing machine, for items too big to hand-wash in the sink.".
+
+Out-direction of Galley is up. [Back up to navigation area]
 
 A built-in table is scenery in the Galley. It is a supporter. The description is "When the weather is good and there is nothing urgent happening, you all often eat out on the sunning deck, which is more congenial; but at other times you take your meals down here, on this table. The seating is built-in.". Some seating is part of the built-in table. The seating is an enterable supporter. Understand "built-in seating" as the seating.
 
@@ -1230,7 +1244,7 @@ Brock's Stateroom is fore from the Galley. It is nautical.  It is indoors. The d
 
 The shape of hull in this part of the yacht means that the room is much narrower fore than aft, the walls sweeping grandly outward from the head of [Brock's bed]. It looks like the bed of Captain Horndog, Space Woman[ize]r. If you ask me."
 
-
+Out-direction of Brock's Stateroom is aft. [Back to galley]
 
 Brock's bed is a yacht bed in Brock's Stateroom. It is scenery. The description is "Brock affects a kind of ruffled bachelor style, which means that his bed is made but the blankets suggestively rumpled. It is an open question whether he rumples them himself on purpose."
 
@@ -1314,6 +1328,8 @@ Section 8 - Your Bunk
 
 Your Bunk is aft-starboard from the Galley.  It is nautical .  It is indoors. The description is "Amazing: it's even tinier than my apartment, and the bed isn't even a twin in width. Across from the bed is a built-in [bench], with [random portholes] above, just at the waterline."
 
+Out-direction of Your bunk is fore-port. [Back to galley]
+
 The bench is an enterable supporter in Your Bunk. It is scenery. The description is "It's hard and less comfortable than a sofa, but it is adequate for seating on the rare occasions when a second person comes into your room. Mostly you read on the bed."
 
 Some financial records are a thing. The clipping is a thing. The description of the financial records is "Brock and Slango managed for you at first, depositing your part of job commissions into a Swiss bank account. It is only recently that you've started to branch out in managing that money. After your wire transfer to your brother, you have only a few tens of thousands of dollars left, but that will change when you get your share for rescuing the plans of the T-inserter."
@@ -1376,6 +1392,8 @@ Your Head is aft from Your Bunk. It is nautical. It is a bathroom.  It is indoor
 Section 11 - Slango's Bunk
 
 Slango's Bunk is aft-port from the Galley.  It is nautical.  It is indoors. The description is "Just as tiny as yours, with a bed narrower than a standard twin, and its own miniature head, and drawers cunningly fitted under the bed to hold clothing and other necessities."
+
+Out-direction of Slango's bunk is fore-starboard. [Back to galley]
 
 Instead of going fore in Slango's Bunk:
 	try going fore-starboard.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -1756,13 +1756,6 @@ Some dim lights are scenery in the Shadow Chamber. The description is "They glow
 
 The passage-exit is a door. It is scenery. The printed name is "passage". Understand "passage" or "exit" or "passageway" as the passage-exit. It is above Shadow Chamber. Through the passage-exit is the Workshop. The description of the passage-exit is "The way back to the Workshop is entirely dark."
 
-Sanity-check exiting in Shadow Chamber:
-	if the player is in an enterable thing:
-		make no decision;
-	if the player is on an enterable thing:
-		make no decision;
-	try going up instead.
-
 Instead of entering the passage-place:
 	say "[We] clamber down into the passage. It feels disconnected from other places, as though it didn't belong here at all. Soon we can't see the light from the door.";
 	now the player is in the Shadow Chamber;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -465,6 +465,7 @@ Understand "pound face" as testing facing. Testing facing is an action out of wo
 Carry out testing facing:
 	repeat with item running through rooms:
 		move the player to item;
+		carry out the caching scope activity with player;
 		say "[line break] north: ";
 		try facing north;
 		say "[line break] northwest: ";
@@ -484,7 +485,54 @@ Carry out testing facing:
 		say "[line break] down: ";
 		try facing down;
 		say "[line break] up: ";
-		try facing up.
+		try facing up;
+		say "[line break] in: ";
+		try facing inside;
+		say "[line break] out: ";
+		try facing outside.
+
+
+Understand "pound insides" and "pound outsides" as testing insides. Testing insides is an action out of world.
+
+Carry out testing insides:
+	try unmonkeying;
+	try deparkering;
+	repeat with item running through rooms:
+		say "(Testing insides and outsides of [item])";
+		move player to item;
+		carry out the caching scope activity with player;
+		say "> GO IN";
+		let way be in-direction of item;
+		if way is a direction:
+			let R be the room the way from location;
+			if R is a room:
+				say "[line break](Going inside from [the item] will take the player [way] to [R])[paragraph break]";
+			otherwise:
+				try going inside;
+		otherwise:
+			say "[line break]([Item] has no in-direction property)";
+			try going inside;
+		say "> LOOK IN";
+		try facing inside;
+		say "> GO OUT";
+		let way be out-direction of item;
+		if way is a direction:
+			let R be the room the way from location;
+			if R is a room:
+				say "[line break](Going outside from [the item] will take the player [way] to [R])[paragraph break]";
+			otherwise:
+				try going outside;
+		otherwise:
+			say "[line break]([Item] has no out-direction property)";
+			if item is dead-end:
+				let way be a random exit-listable direction;
+				say "[line break](but because there is only one way out of here, going out will take us [way] to [the room way from location])[paragraph break]";
+			otherwise:
+				try going outside;
+		say "> LOOK OUT";
+		try facing outside.
+
+
 
 Understand "pound all-lists" as pounding all-lists. Pounding all-lists is an action out of world.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -718,11 +718,20 @@ Instead of going nowhere when the noun is fronted by a facade (called blockage) 
 	say "[closure notice of the blockage][run paragraph on]";
 	carry out the listing exits activity.
 
-Instead of going nowhere when the noun is not fronted by a facade in the location:
-	if the noun is up or the noun is inside or the noun is outside:
-		say "There is no way [noun].[paragraph break]";
-	else:
-		try facing the noun;
+Instead of going nowhere when the noun is not fronted by a facade in the location (this is the handle can't-go-that-way rule):
+	if the noun is inside:
+		if in-direction of location is a direction:
+			try going in-direction of location instead;
+		otherwise:
+			follow the attempt going in rule instead;
+	if the noun is outside:
+		if out-direction of location is a direction:
+			try going out-direction of location instead;
+		otherwise:
+			follow the attempt going out rule instead;
+	if the noun is up:
+		say "There is no way upwards. [run paragraph on]";
+	try facing the noun;
 	carry out the listing exits activity.
 
 [The parser would sometimes misinterpret commands such as GO TO CINEMA as FIND CINEMA-EXTERIOR and leave the player in from of the cinema rather than inside it. This gets around this by making sure that we always try to walk through any facade that we are "finding".]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/insides and outsides.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/insides and outsides.i7x
@@ -1,0 +1,127 @@
+Insides and Outsides by Counterfeit Monkey begins here.
+
+Use authorial modesty.
+
+This is the attempt going in rule:
+	let C be car-or-container;
+	if C is enterable:
+		say "([the C])";
+		try entering C instead;
+	otherwise:
+		say "Any particular direction? ";
+		carry out the listing exits activity.
+
+This is the attempt going out rule:
+	if the player is in an enterable thing:
+		try exiting;
+	otherwise:
+		try departing the location.
+
+Instead of facing outside:
+	if the actor is in a container (called the box):
+		if the box is closed and the box is opaque:
+			say "[The actor] can't see outside [the box].";
+		otherwise:
+			say "(looking outside [the box])[line break]";
+			try looking;
+	otherwise:
+		if the out-direction of the location is a direction:
+			if the out-direction of the location is outside:
+				continue the action;
+			otherwise:
+				try facing out-direction of location;
+		otherwise:
+			if the location is outdoors:
+				say "[The actor] [are] not in anything at the moment.";
+			otherwise:
+				say "[The actor] can't see outside from here."
+
+Instead of facing outside in the Old Hexagonal Turret:
+	try examining the sea.
+
+Instead of facing outside in the Tin Hut:
+	say "([the circular windows])";
+	try searching the circular windows.
+
+Instead of facing outside in the Church Garden:
+	try facing west.
+
+Instead of facing inside in Old City Walls:
+	say "([the turret-view])";
+	try examining turret-view.
+
+Instead of facing outside when location is nautical and location is indoors:
+	if there are portholes in location:
+		let P be random portholes in location;
+		try searching P;
+	otherwise:
+		say "There are no portholes here."
+
+Instead of facing outside when location is nautical and location is outdoors:
+	say "No one appears to be approaching the ship or attempting to follow us, which is the main thing."
+
+Instead of facing inside:
+	if the in-direction of location is a direction:
+		let dir be in-direction of location;
+		if dir is inside:
+			continue the action;
+		let D be the door dir from the location;
+		if D is not a door:
+			let D be a random marked-visible facade fronting dir;
+		if D is something:
+			say "([the D])";
+			try searching D instead;
+		otherwise:
+			try facing dir instead;
+	otherwise:
+		let C be car-or-container;
+		if C is something:
+			say "([the C])";
+			try searching C instead;
+	say "[one of]What should [we] look inside, exactly?[or][We]['re] not sure what to look inside here.[at random]"
+
+To decide which object is car-or-container:
+	if there is a car (called C) in location:
+		decide on C;
+	let B be a random marked-visible container in location;
+	if B is a box listed in the Table of Obvious Containers to Look Inside:
+		decide on B;
+	otherwise:
+		decide on nothing.
+
+Instead of exiting when the player is not in an enterable thing:
+	try going outside.
+
+Understand "get out of [thing]" or "exit [thing]" as getting out. Getting out is an action applying to one thing.
+
+Carry out getting out:
+	if the actor is in the noun:
+		try exiting;
+	otherwise:
+		say "[The actor] [are] not in [the noun]."
+
+A room has an object called in-direction. The in-direction of a room is usually nothing.
+A room has an object called out-direction. The out-direction of a room is usually nothing.
+
+Table of Obvious Containers to Look Inside
+box (a thing)
+the backpack
+the projector
+the depluralizing cannon
+the locker
+the crate
+the shopping bag
+the plexiglas case
+the large carton
+the reclamation machine 
+the shed
+the wall-hole
+the bin
+the display case
+the t-inserter machine
+the cryptolock
+the secret-door
+the kayak
+your wardrobe
+
+Insides and Outsides ends here.


### PR DESCRIPTION
In the original code the standard Inform INSIDE and OUTSIDE directions are only used in the traffic circle, but they can be tried anywhere, with responses such as "That way is the corner of Sigil Street and Sigil Street" or "To the outside the Church Forecourt meets the Church Forecourt". There is also a leave [any room] command that will take us out the only exit in dead end rooms.

In the Cinema Lobby there is a check to take you west if you type GO INSIDE, and I found I wanted to add more and more of these: one that would go east if typing GO INSIDE outside the hostel and so on. So I figured I might as well add them all at once.

This PR implements IN and OUT as valid directions wherever deemed appropriate. I was worried that adding the standard inside and outside directions would interfere with pathfinding and exits listing, so instead every room now has the new properties in-side and out-side, that are set to the direction GO OUT or GO IN will take you in.

I also found that the directions that seem appropriate for _looking_ in and out are not necessarily the same as those you want for _going_ in and out, so I've tried accounting for that. In particular there is some code (and a table) to determine if any container in a room seems a good candidate for LOOK INSIDE. I also implemented GET OUT OF [container].

There are two testing commands, POUND FACE (an old one for testing facing responses, now with added inside and outside directions) and POUND INSIDES, that will run through every room in the game and demonstrate the new functionality.

This could probably still do with a bit of polish and paring-down. Any comments are welcome.

EDIT: This supercedes #17 as well, and it would be nice to hear Emily's opinion on this changed behavior, so I'll set her feedback tag on this as well.