### PR TITLE
Shorter multiple-objects action lists

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -150,6 +150,7 @@ Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 		•	Section 6 - The THINK verb ]
 	
 Include World Model Tweaks by Counterfeit Monkey.
+Include Actions on Multiple Objects by Counterfeit Monkey.
 
 [	•	Book 4 - Default World Model Tweaks
 		•	Part 1 - Parsing and Verb Handling
@@ -158,7 +159,6 @@ Include World Model Tweaks by Counterfeit Monkey.
 			•	Section 3 - Miscellaneous Verbs
 			•	Section 4 - Miscellaneous Class Vocabulary
 			•	Section 5 - Sanity and Accessibility
-			•	Section 6 - Actions on multiple objects
 		•	Part 2 - Senses
 			•	Section 1 - Smell and Taste
 			•	Section 2 - Loudness
@@ -544,6 +544,7 @@ Include Presentation Details by Counterfeit Monkey.
 Include Character Models by Counterfeit Monkey.
 Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 Include World Model Tweaks by Counterfeit Monkey.
+Include Actions on Multiple Objects by Counterfeit Monkey.
 Include Features of Created Objects by Counterfeit Monkey.
 Include Schedule and Time by Counterfeit Monkey.
 Include Act I Among Sightseers by Counterfeit Monkey.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -1441,7 +1441,7 @@ It looks wrong, of course, because the motte belongs to medieval castle construc
 
 The mu is an illegal r-abstract thing. The description is "μ. Just the letter, but that's a dangerous thing around here."
 
-The mug is a container. The heft of the mug is 2. The carrying capacity of the mug is 1.
+The mug is a container. The heft of the mug is 2. The carrying capacity of the mug is 2.
 	The description of the mug is "It's a super-sized black mug with 'TEA INSERTION GROUP' on the side in crisp white letters. Must be an employee gift over at Dental Consonants Limited."
 
 Check inserting something into the mug when the heft of the noun is greater than 1:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -486,6 +486,101 @@ Carry out testing facing:
 		say "[line break] up: ";
 		try facing up.
 
+Understand "pound all-lists" as pounding all-lists. Pounding all-lists is an action out of world.
+
+Carry out pounding all-lists:
+	let L be a list of things;
+	let all-list be { tomcat, apple, stick, cream };
+	repeat with C running through containers:
+		add C to L;
+	remove the repository from L;
+	remove the backup-repository from L;
+	remove quip-repository from L;
+	repeat with S running through supporters:
+		add S to L;
+	repeat with F running through fluid things:
+		add F to L;
+	repeat through the Table of snarky supporters:
+		add support entry to L;
+	repeat through the Table of unsuitable supporters:
+		add support entry to L;
+	repeat through the Table of unsuitable containers:
+		add box entry to L;
+	repeat through the Table of snarky containers:
+		add box entry to L;
+	sort L in printed name order; [remove any duplicates in the list]
+	let last be nothing;
+	let L2 be a list of things;
+	let N be text;
+	let D be 0;
+	repeat with obj running through L:
+		let N1 be printed name of obj;
+		let D1 be the number of words in description of obj; [checking the printed name and the number of words in description seems to be the best way to see if two objects are identical instances of the same kind, and only fails for the tent(s) because of the random description.]
+		unless obj is last or (N1 is N and D1 is D):
+			add obj to L2;
+			now last is obj;
+			now N is N1;
+			now D is D1;
+	now L is L2;
+	repeat with item running through L:
+		now the second noun is item;
+		say "[bold type][The item][roman type][line break]";
+		if item is enclosed by a room (called R):
+			unless R is location:
+				move player to R, without printing a room description;
+				say "(moving to [the R])[line break]";
+		otherwise:
+			unless item is a backdrop:
+				move item to location;
+				say "(moving [the item] to [the location])[line break]";
+			otherwise:
+				now item is everywhere;
+		repeat with obj running through all-list:
+			move obj to player;
+		say "(examine [the item])";
+		try examining the item;
+		say "(remove all from [the item])";
+		if item is empty:
+			try empty-removing item;
+		otherwise:
+			let H be a list of things;
+			repeat with obj running through things held by item:
+				unless obj is scenery or obj is part of item:
+					add obj to H;
+			alter the multiple object list to H;
+			follow the stop removing error list rule;
+			repeat with obj running through multiple object list:
+				say "[obj]: [run paragraph on]";
+				try removing obj from item;
+			if multiple object list is empty:
+				say "That can't contain things.";
+		say "(put all on [item])";
+		repeat with obj running through all-list:
+			move obj to player;
+		alter the multiple object list to all-list;
+		follow the stop putting error list rule;
+		repeat with obj running through the multiple object list:
+			say "[obj]: [run paragraph on]";
+			try putting obj on item;
+		say "(put all in [item])";
+		alter the multiple object list to all-list;
+		follow the stop inserting error list rule;
+		repeat with obj running through the multiple object list:
+			say "[obj]: [run paragraph on]";
+			try inserting obj into item;
+		move spill to location;
+		say "(put spill in [item])";
+		try inserting spill into item;
+		say "(put spill on [item])";
+		try putting spill on item;
+		move apple to player;
+		say "(put apple on [item])";
+		try putting the apple on item;
+		say "(put apple in [item])";
+		try inserting the apple into item;
+		say "(remove apple from [item])";
+		try removing apple from item;
+
 [Object responses for everything in the repository.]
 
 Include Object Response Tests by Juhana Leinonen.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -167,10 +167,6 @@ Sanity-check inserting something (called the target) into the target:
 Sanity-check inserting something in a container (called the target) into the target:
 	say "[The noun] [are] in [the target] already." instead.
 
-Sanity-check putting something (called the target) on the target:
-	unless the target is the tube and the player's command includes "gel on/onto":
-		say "[We] can't put [the target] on [themselves]." instead.
-
 Sanity-check putting something (called the source) on a supporter (called the target) when the source is on the target:
 	say "[The source] [are] on [the target] already." instead.
 
@@ -354,77 +350,6 @@ Instead of drinking something which is not fluid:
 
 Understand "apply pressure to [something]" as pushing.
 Understand "lean on [something]" as pushing.
-
-Section 6 - Actions on multiple objects
-
-Rule for deciding whether all includes fixed in place things: it does not.
-Rule for deciding whether all includes scenery: it does not.
-Rule for deciding whether all includes people while taking: it does not.
-Rule for deciding whether all includes things carried by other people while taking: it does not.
-
-Rule for deciding whether all includes other people carried by the person asked while dropping or throwing or inserting or putting (this is the new exclude people from drop all rule):
-	it does.
-
-[Hack to avoid "What do you want to drop those things in?" when typing DROP ALL while carrying nothing.]
-Rule for deciding whether all includes the person asked while dropping:
-	if the person asked is empty:
-		it does.
-
-A multiple action processing rule when dropping:
-	if the player is empty:
-		alter the multiple object list to {};
-		say "[We] don't have anything to drop.";
-	otherwise:
-		let L be the multiple object list;
-		if the player is listed in L:
-			remove player from L;
-			alter the multiple object list to L.
-
-The new exclude people from drop all rule is listed instead of the exclude people from drop all rule in the for deciding whether all includes rulebook.
-
-Rule for clarifying the parser's choice of something:
-	do nothing instead.
-
-[The empty-removing action makes it possible to give custom replies to trying to remove all from an empty container or supporter]
-Understand "remove all/everything from [an empty container]" or "take all/everything from [an empty container]" or "get all/everything from [an empty container]" as empty-removing.
-
-Understand "remove all/everything from [an empty supporter]" or "take all/everything from/off [an empty supporter]" or "get all/everything from/off [an empty supporter]" as empty-removing.
-
-Empty-removing is an action applying to one thing.
-
-Carry out empty-removing:
-	if the noun is closed and noun is opaque and the noun is a container:
-		say "[The noun] [aren't] open.";
-	otherwise:
-		say "[The noun] [are] empty.";
-
-[Preventing long lists of error messages when typing things like "put all in rock"]
-
-A multiple action processing rule when the action name part of the current action is the putting it on action (this is the stop putting error list rule):
-	if the second noun is not a supporter:
-		alter the multiple object list to {};
-		say "Putting things on [the second noun] would achieve nothing."
-
-A multiple action processing rule when the action name part of the current action is inserting it into action (this is the stop inserting error list rule):
-	if the second noun is gel-related:
-		if the second noun is the tube:
-			say "The tube's opening is too small.";
-		otherwise:
-			say "That would only make a mess. Try rubbing the [if the second noun is the paste]paste[otherwise]gel[end if] on things instead.";
-		alter the multiple object list to {};
-		make no decision;
-	otherwise:
-		if the second noun is not a container:
-			alter the multiple object list to {};
-			say "[The second noun] can't contain things.";
-			make no decision;
-	if the second noun is the toolkit:
-		alter the multiple object list to {};
-		say "[The toolkit] is full already."
-
-This is the cancel multiple rule:
-	alter the multiple object list to {};
-	the rule fails.
 
 Part 2 - Senses
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
@@ -56,22 +56,29 @@ This is the stop putting error list rule:
 	abide by the check self-containment rule;
 	if the number of entries in the multiple object list is less than 2:
 		the rule succeeds;
-	if the second noun is the hard wood floors or the second noun is the tiny refrigerator:
-		the rule succeeds;
-	if the second noun is enclosed by the display case:
-		abide by the display-case-closed rule;
-	if the second noun is a support listed in the Table of snarky supporters:
-		abide by the fake put on rule;
 	if the second noun is a support listed in the Table of unsuitable supporters or the second noun is a pan:
 		say "It makes no sense to put a lot of random stuff on [the second noun].";
 		abide by the cancel multiple rule;
-	if the location is privately-controlled and the second noun is not enclosed by the player:
-		abide by the fake put on rule;
-	if the second noun is not a supporter:
+	if the second noun is single put on only:
 		abide by the fake put on rule;
 	otherwise:
 		if the second noun is not touchable:
 			abide by the try reaching rules for the second noun.
+
+Definition: a thing is single put on only:
+	if it is the hard wood floors:
+		no;
+	if it is the tiny refrigerator:
+		no;
+	if it is a support listed in the Table of snarky supporters:
+		yes;
+	if it is not a supporter:
+		yes;
+	if it is enclosed by the display case:
+		yes;
+	if it is not enclosed by the player and the location is privately-controlled:
+		yes.
+
 
 [To make sure that we don't try things like inserting the bag in the pan when the pan already is inside the bag. That is blocked further down the line too, but this rule prevents that ugly error messages are printed at the wrong time.]
 This is the check self-containment rule:
@@ -108,8 +115,6 @@ This is the stop inserting error list rule:
 	if the number of entries in the multiple object list is less than 2:
 		the rule succeeds;
 	abide by the check multiple insert rules for the second noun;
-	if the location is privately-controlled and the second noun is not enclosed by the player:
-		abide by the fake insert rule;
 	if the second noun is not touchable:
 		abide by the try reaching rules for the second noun;
 	if the second noun is closed:
@@ -128,32 +133,21 @@ A check multiple insert rule for the shrine:
 		say "One thing at a time.";
 		abide by the cancel multiple rule;
 
-A check multiple insert rule for something that is enclosed by the display case:
-	abide by the display-case-closed rule.
-
-A check multiple insert rule for something (called the target) (this is the handle multiple inserts into kinds rule):
-	if the target is a desk, abide by the fake insert rule;
-	if the target is a tin-can, abide by the fake insert rule;
-	if the target is a drain, abide by the fake insert rule;
-	if the target is a freezer compartment, abide by the fake insert rule;
-	if the target is a power socket, abide by the fake insert rule.
-
-A check multiple insert rule for something (called the target):
-	if the target is a box listed in the Table of snarky containers:
-		abide by the fake insert rule.
-
-A check multiple insert rule for something (called the target):
-	if the target is a box listed in the Table of unsuitable containers or the carrying capacity of target is 1:
+A check multiple insert rule for a thing (called the target) (this is the check for unsuitable containers rule):
+	if the target is a box listed in the Table of unsuitable containers or the carrying capacity of target is less than 3:
 		say "It makes no sense to insert a lot of random things in [the target].";
 		abide by the cancel multiple rule.
 
-A last check multiple insert rule for something (called target) that is not a container:
-	unless target incorporates a drawer or target incorporates an oven:
-		abide by the fake insert rule;
-	otherwise:
-		now second noun is a random drawer incorporated by target;
-		if second noun is nothing:
-			now second noun is a random oven incorporated by target.
+A check multiple insert rule for a single insert only thing (this is the check for single insert containers rule):
+	abide by the fake insert rule.
+
+The check for unsuitable containers rule is listed before the check for single insert containers rule in the check multiple insert rules.
+
+A last check multiple insert rule for something that incorporates a drawer (called target drawer):
+	now second noun is target drawer;
+		
+A last check multiple insert rule for something that incorporates an oven (called target oven):
+	now second noun is target oven;
 
 [These are used to give a single reply to an action on multiple object, using a dummy object to get a sensible noun name:]
 This is the fake insert rule:
@@ -173,6 +167,28 @@ Dummy-object is a proper-named thing. The printed name of dummy-object is "[if l
 This is the cancel multiple rule:
 	alter the multiple object list to {};
 	the rule fails.
+
+Definition: a thing is single insert only:
+	if it incorporates a drawer:
+		no;
+	if it incorporates an oven:
+		no;
+	if it is a desk:
+		yes;
+	if it is a tin-can:
+		yes;
+	if it is a drain:
+		yes;
+	if it is a freezer compartment:
+		yes;
+	if it is a box listed in the Table of snarky containers:
+		yes;
+	if it is not a container:
+		yes;
+	if it is enclosed by the display case:
+		yes;
+	if it is not enclosed by the player and the location is privately-controlled:
+		yes.
 
 [The things listed in this table gives a single custom reply when trying to put all on them.]
 Table of snarky supporters
@@ -247,8 +263,8 @@ till
 mutual punch
 pulley
 reclamation machine
-mug
 pen
+mug
 
 Table of Ultratests (continued)
 topic	stuff	setting

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
@@ -1,0 +1,258 @@
+Actions on Multiple Objects by Counterfeit Monkey begins here.
+
+Use authorial modesty.
+
+Section 6 - Actions on multiple objects
+
+Rule for deciding whether all includes fixed in place things: it does not.
+Rule for deciding whether all includes scenery: it does not.
+Rule for deciding whether all includes people while taking: it does not.
+Rule for deciding whether all includes things carried by other people while taking: it does not.
+Rule for deciding whether all includes other people carried by the person asked while dropping or throwing or inserting or putting (this is the new exclude people from drop all rule):
+	it does.
+
+The new exclude people from drop all rule is listed instead of the exclude people from drop all rule in the for deciding whether all includes rulebook.
+
+[Hack to avoid "What do you want to drop those things in?" when typing DROP ALL while carrying nothing.]
+Rule for deciding whether all includes the person asked while dropping:
+	if the person asked is empty:
+		it does.
+
+[The empty-removing action makes it possible to give custom replies to trying to remove all from an empty container or supporter. Without this we would have to hack the default parser error messages.]
+Understand "remove all/everything from [an empty container]" or "take all/everything from [an empty container]" or "get all/everything from [an empty container]" as empty-removing.
+Understand "remove all/everything from [an empty supporter]" or "take all/everything from/off [an empty supporter]" or "get all/everything from/off [an empty supporter]" as empty-removing.
+
+Empty-removing is an action applying to one thing.
+
+Carry out empty-removing:
+	if the noun is closed and noun is opaque and the noun is a container:
+		say "[The noun] [aren't] open.";
+	otherwise:
+		say "[The noun] [are] empty.";
+
+[Prevent long lists of error messages when typing things like "put all in rock":]
+
+[First "drop all"]
+A multiple action processing rule when dropping:
+	if the player is empty:
+		alter the multiple object list to {};
+	otherwise:
+		let L be the multiple object list;
+		if the player is listed in L:
+			remove player from L;
+			alter the multiple object list to L;
+	if the multiple object list is empty:
+		say "[We] don't have anything to drop.";
+	otherwise if the location is privately-controlled and the number of entries in the multiple object list is at least 2:
+		now the noun is dummy-object;
+		say "[non-drop-zone]";
+		alter the multiple object list to {}.
+
+[Next "put all on"]
+A multiple action processing rule when the action name part of the current action is the putting it on action:
+	abide by the stop putting error list rule.
+
+This is the stop putting error list rule:
+	abide by the check self-containment rule;
+	if the number of entries in the multiple object list is less than 2:
+		the rule succeeds;
+	if the second noun is the hard wood floors or the second noun is the tiny refrigerator:
+		the rule succeeds;
+	if the second noun is enclosed by the display case:
+		abide by the display-case-closed rule;
+	if the second noun is a support listed in the Table of snarky supporters:
+		abide by the fake put on rule;
+	if the second noun is a support listed in the Table of unsuitable supporters or the second noun is a pan:
+		say "It makes no sense to put a lot of random stuff on [the second noun].";
+		abide by the cancel multiple rule;
+	if the location is privately-controlled and the second noun is not enclosed by the player:
+		abide by the fake put on rule;
+	if the second noun is not a supporter:
+		abide by the fake put on rule;
+	otherwise:
+		if the second noun is not touchable:
+			abide by the try reaching rules for the second noun.
+
+[To make sure that we don't try things like inserting the bag in the pan when the pan already is inside the bag. That is blocked further down the line too, but this rule prevents that ugly error messages are printed at the wrong time.]
+This is the check self-containment rule:
+	if the holder of the second noun is listed in the multiple object list:
+		let L be the multiple object list;
+		remove the holder of the second noun from L;
+		alter the multiple object list to L;
+		if L is empty:
+			say "There are none at all available!";
+			the rule fails.
+
+[Then "remove all from"]
+A multiple action processing rule when the action name part of the current action is the removing it from action:
+	abide by the stop removing error list rule.
+
+This is the stop removing error list rule:
+	if the second noun is toolkit or the second noun is heavy pack or second noun is tub:
+		try removing the first thing held by the second noun from the second noun;
+		abide by the cancel multiple rule;
+	if second noun is enclosed by display case or second noun is display case:
+		say "[no stealing from display case]";
+		abide by the cancel multiple rule;
+	if the second noun is not touchable:
+		abide by the try reaching rules for the second noun;
+	if the second noun is closed:
+		abide by the try opening rules for the second noun.
+	
+[And finally "insert all into"]
+A multiple action processing rule when the action name part of the current action is inserting it into action:
+	abide by the stop inserting error list rule.
+
+This is the stop inserting error list rule:
+	abide by the check self-containment rule;
+	if the number of entries in the multiple object list is less than 2:
+		the rule succeeds;
+	abide by the check multiple insert rules for the second noun;
+	if the location is privately-controlled and the second noun is not enclosed by the player:
+		abide by the fake insert rule;
+	if the second noun is not touchable:
+		abide by the try reaching rules for the second noun;
+	if the second noun is closed:
+		abide by the try opening rules for the second noun.
+
+[A rulebook to give sensible reactions to "insert all into". This is mostly to make the the stop inserting error list rule above more readable.]
+
+The check multiple insert rules are an object-based rulebook.
+
+A first check multiple insert rule for the tub:
+	if tub is closed and the tub is touchable:
+		silently try opening the tub.
+
+A check multiple insert rule for the shrine:
+	if the the bushes are shrine-revealing:
+		say "One thing at a time.";
+		abide by the cancel multiple rule;
+
+A check multiple insert rule for something that is enclosed by the display case:
+	abide by the display-case-closed rule.
+
+A check multiple insert rule for something (called the target) (this is the handle multiple inserts into kinds rule):
+	if the target is a desk, abide by the fake insert rule;
+	if the target is a tin-can, abide by the fake insert rule;
+	if the target is a drain, abide by the fake insert rule;
+	if the target is a freezer compartment, abide by the fake insert rule;
+	if the target is a power socket, abide by the fake insert rule.
+
+A check multiple insert rule for something (called the target):
+	if the target is a box listed in the Table of snarky containers:
+		abide by the fake insert rule.
+
+A check multiple insert rule for something (called the target):
+	if the target is a box listed in the Table of unsuitable containers or the carrying capacity of target is 1:
+		say "It makes no sense to insert a lot of random things in [the target].";
+		abide by the cancel multiple rule.
+
+A last check multiple insert rule for something (called target) that is not a container:
+	unless target incorporates a drawer or target incorporates an oven:
+		abide by the fake insert rule;
+	otherwise:
+		now second noun is a random drawer incorporated by target;
+		if second noun is nothing:
+			now second noun is a random oven incorporated by target.
+
+[These are used to give a single reply to an action on multiple object, using a dummy object to get a sensible noun name:]
+This is the fake insert rule:
+	move dummy-object to player;
+	try inserting dummy-object into second noun;
+	now dummy-object is nowhere;
+	abide by the cancel multiple rule.
+
+This is the fake put on rule:
+	move dummy-object to player;
+	try putting dummy-object on the second noun;
+	now dummy-object is nowhere;
+	abide by the cancel multiple rule.
+
+Dummy-object is a proper-named thing. The printed name of dummy-object is "[if location is privately-controlled or the second noun is fluid]our things[otherwise][one of]stuff[or]things[at random][end if]".
+
+This is the cancel multiple rule:
+	alter the multiple object list to {};
+	the rule fails.
+
+[The things listed in this table gives a single custom reply when trying to put all on them.]
+Table of snarky supporters
+Support (a thing)
+sea-view
+word-balance
+department printer
+oval table
+altar
+the output tray
+the heavy pack
+mannequin
+shrine
+keyring
+stillage
+the rack
+
+[The things listed in this table gives a the reply "It makes no sense to put a lot of random stuff on" when trying to put all on them.]
+Table of unsuitable supporters
+Support (a thing)
+spinner
+pen
+left pan
+right pan
+the pulley
+diorama table
+portcullis
+projector
+
+[The things listed in this table gives a single custom reply when trying to insert all into them.]
+Table of snarky containers
+Box (a thing)
+Slango's bed
+sea-view
+secret-door
+sugar bowl
+teapot
+fountain
+nightstand
+word-balance
+projector
+shot glasses
+toolkit
+heavy pack
+depluralizing cannon
+department printer
+paper-drawer
+long line
+display case
+tub
+tube
+gel
+origin paste
+long glass case
+shrine
+pit-trap
+
+[The things listed in this table gives a the reply "It makes no sense to insert a lot of random things in" when trying to insert all into them.]
+Table of unsuitable containers
+Box (a thing)
+diorama table
+plywood cutout
+mirth pail
+left pan
+right pan
+keycard-reading lock
+umlaut punch
+contraband box
+hopping bag
+mailboxes
+till
+mutual punch
+pulley
+reclamation machine
+mug
+pen
+
+Table of Ultratests (continued)
+topic	stuff	setting
+"all-lists"	{ apple, tomcat, tube, stick, twig, secret-plans, backpack, card, letter-remover, origin paste }	Tools Exhibit
+
+Test all-lists with "tutorial off / get all from tube / put all in tube / put all in paste / wave e-remover at tube / get gel / get gel from tub / put all in tub / get all from tub / wave l-remover at plans / wave s-remover at pans / wave d-remover at card / put all in pan / get pan / put all in backpack / look in backpack / enter car / close car / put car in backpack / put all in backpack / get out / get backpack / get all from backpack / get all from platform / put all on platform / put all in chamber / get all from chamber".
+Actions on Multiple Objects ends here.


### PR DESCRIPTION
Even more than #44 this is a lot of code (and work) to avoid a rather minor annoyance. 

This game allows the use of multiple objects with five actions (I think): take all, drop all, get all from, put all on and insert all in. 

In particular the last two would originally cause really long lists of "x-remover: Putting things on the marble fountain would achieve nothing" and so on, sometimes over a hundred lines long. As a player, you feel that printing that message once would have been enough. So I've gone to some lengths to accomplish exactly that. If you're not actually allowed to put all your stuff in a container or on a supporter, this tries to reduce the list to a single error message, either the same custom message that you get when carrying out the action with a single object, or something like "It makes no sense to insert a lot of random things in [the target]."

EDIT: Added a test command, POUND ALL-LISTS, that goes through every container and supporter in the game and tries out the multiple object actions on them.