### PR TITLE
Liquid behavior

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -151,6 +151,7 @@ Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 	
 Include World Model Tweaks by Counterfeit Monkey.
 Include Insides and Outsides by Counterfeit Monkey.
+Include Liquids by Counterfeit Monkey.
 Include Actions on Multiple Objects by Counterfeit Monkey.
 
 [	•	Book 4 - Default World Model Tweaks
@@ -197,8 +198,7 @@ Include Actions on Multiple Objects by Counterfeit Monkey.
 				•	Section 1 - Books
 				•	Section 2 - Computers
 			•	Chapter 2 - Substances
-				•	Section 1 - Liquids
-				•	Section 2 - Vegetables
+				•	Section 1 - Vegetables
 			•	Chapter 3 - Useful Items
 				•	Section 1 - Holdall
 				•	Section 2 - Clothing
@@ -546,7 +546,8 @@ Include Character Models by Counterfeit Monkey.
 Include Viewpoint and Narrative Voice by Counterfeit Monkey.
 Include World Model Tweaks by Counterfeit Monkey.
 Include Insides and Outsides by Counterfeit Monkey
-Include Actions on Multiple Objects by Counterfeit Monkey..
+Include Liquids by Counterfeit Monkey.
+Include Actions on Multiple Objects by Counterfeit Monkey.
 Include Features of Created Objects by Counterfeit Monkey.
 Include Schedule and Time by Counterfeit Monkey.
 Include Act I Among Sightseers by Counterfeit Monkey.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -877,11 +877,6 @@ Understand "put [word-balance] out of alignment" or "unbalance [word-balance]" o
 
 A ranking rule for the word-balance: increase description-rank of the word-balance by 50.
 
-Every turn when a fluid thing (called target) is in a pan:
-	unless the target is contained:
-		move the target to the location;
-		say "[The target] runs rapidly out through the slots of the pan."
-
 Every turn:
 	if the word-balance is tilting and the barker is in location
 	begin;
@@ -2684,16 +2679,17 @@ The funnel can be buried or unburied. The funnel is buried.
 Sanity-check rubbing the sand when the funnel is buried:
 	try digging in the sand instead.
 
-Sanity-check inserting the funnel into the fountain:
-	try washing the funnel instead.
-
 Instead of washing the funnel in the presence of the fountain:
 	say "We dip the funnel in the water and quickly shake it dry.";
 	now the description of the funnel is "A gaudy green plastic toy suitable for funneling water and shaping conical sand-turrets."
 
-Instead of washing the funnel when the player can touch a sink (called target sink):
-	now the description of the funnel is "A gaudy green plastic toy suitable for funneling water and shaping conical sand-turrets.";
-	say "[We] run some water from [the target sink] over [the funnel], leaving it glistening and clean."
+Before washing the funnel when the player can touch a tap (called target tap):
+	if target tap is switched off:
+		silently try switching on target tap;
+	if target tap is switched on:
+		now the description of the funnel is "A gaudy green plastic toy suitable for funneling water and shaping conical sand-turrets.";
+		say "[We] run some water from [the target tap] over [the funnel], leaving it glistening and clean.";
+		silently try switching off target tap instead.
 
 Instead of rubbing the funnel:
 	if the funnel is buried:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -111,15 +111,27 @@ Section 4 - Public Convenience
 
 [The public convenience existed from a fairly early stage of the game development, as a place to change your wig or look in the mirror or acquire some soap. The dead-drop puzzle was a late addition to the game, and it came about because I felt that I wanted to make the espionage aspects more convincingly espionage-y. I used this excuse to read a couple of LeCarré novels — research, you see — and then extracted the concepts that I thought would be easiest to transfer into the context of IF.]
 
-The Public Convenience is east of Bus Station. It is indoors and southern. The Public Convenience is a public restroom. The description of Public Convenience is "There are just the two toilet stalls[if at least two sinks are in the location] and a couple of [sink-collectives], but the place has been kept up reasonably well, if one doesn't count the [random graffiti][otherwise if one sink is in the location] and a single [random sink in location], the other one having been vandalized. The [random graffiti] adds a grim touch[otherwise] though both sinks are gone and there is [random graffiti] on the walls[end if]."
+The Public Convenience is east of Bus Station. It is indoors and southern. The Public Convenience is a public restroom. The description of Public Convenience is "There are just the two toilet stalls[if at least two sinks are in the location] and a couple of [sink-collectives], but the place has been kept up reasonably well, if one doesn't count the [random graffiti][otherwise if one sink is in the location] and a single [random sink in location], the other one having been vandalized. The [random graffiti] adds a grim touch[otherwise], though both sinks are gone and there is [random graffiti] on the walls[end if]."
 
 The introduction of the Public Convenience is "A faint smell of lavender lingers in the air."
 
 Out-direction of Public Convenience is west. [To the bus station]
 
-Some sink-collectives are scenery in the public convenience. The sink-collectives are privately-named. The printed name is "sinks".  Understand "sinks" as sink-collectives.
+After reading a command:
+	now the referred of the sink-collectives is false;
+	while the player's command includes "sinks":
+		now the referred of the sink-collectives is true;
+		replace the matched text with "sink".
 
-Sanity-check doing something other than examining to the sink-collectives:
+Some sink-collectives are scenery in the public convenience. The sink-collectives are privately-named. The sink-collectives have a truth state called referred. The printed name is "sinks". Understand "sink" as sink-collectives when there is no sink in location.
+
+Instead of examining a sink when the referred of the sink-collectives is true and there is more than one sink in location:
+	say "The sinks are nothing special. Clean enough, I suppose."
+
+Instead of waving the letter-remover at the sink-collectives:
+	try examining the sink-collectives.
+
+Instead of doing something to the sink-collectives:
 	if the number of sinks in the location is 0:
 		say "[We][']ve already gotten rid of all the sinks to be found in this area." instead;
 	let target be a random sink in the location;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -147,18 +147,22 @@ The soap dispenser is a closed container in the Public Convenience. It is privat
 Does the player mean waving the letter-remover at the soap dispenser:
 	it is very unlikely.
 
-Sanity-check taking the soap when the soap is in the soap dispenser:
-	try squeezing the soap dispenser instead.
+Sanity-check taking the soap dispenser when the soap is in the soap dispenser:
+	if the player's command does not include "dispenser":
+		try squeezing the soap dispenser instead.
 
 Instead of squeezing the soap dispenser:
 	if soap is in the dispenser:
 		if the number of sinks in the location is greater than 0:
-			let target be a random sink;
-			if a marked-visible sink contains an open container (called receptor):
-				now target is the receptor;
+			let target be a random sink in the location;
+			if a switched on tap (called target tap) is part of the target:
+				silently try switching off target tap;
+				say "First switching off [the target tap], [we][run paragraph on]";
 			otherwise:
-				now target is a random sink in the location;
-			say "[We] give the dispenser a squeeze and it deposits some soap in [the target][if the target is a sink] [--] just viscous enough not to drain away instantly[end if].";
+				if a switched on tap (called target tap) is enclosed by location:
+					say "Fortunately, the faucet below the soap dispenser is not running. ";
+				say "[We][run paragraph on]";
+			say " give the dispenser a squeeze. It deposits some soap in [the target] [--] just viscous enough not to drain away instantly.";
 			move the soap to the target;
 		otherwise:
 			say "[We] give the dispenser a squeeze and it deposits some soap on the floor, the sink having been removed from the area.";

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -128,14 +128,17 @@ Some sink-collectives are scenery in the public convenience. The sink-collective
 Instead of examining a sink when the referred of the sink-collectives is true and there is more than one sink in location:
 	say "The sinks are nothing special. Clean enough, I suppose."
 
-Instead of waving the letter-remover at the sink-collectives:
-	try examining the sink-collectives.
+Sanity-check doing something when the sink-collectives is the second noun:
+	if the number of sinks in the location is 0:
+		say "[We][']ve already gotten rid of all the sinks to be found in this area." instead;
+	otherwise:
+		now the second noun is a random sink in location.
 
 Instead of doing something to the sink-collectives:
 	if the number of sinks in the location is 0:
-		say "[We][']ve already gotten rid of all the sinks to be found in this area." instead;
-	let target be a random sink in the location;
-	now the noun is the target.
+		say "[We][']ve already gotten rid of all the sinks to be found in this area.";
+	otherwise:
+		now the noun is a random sink in location.
 
 [After going to Public Convenience:
 	let N be the number of entries in the path so far of the player;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
@@ -783,6 +783,9 @@ Instead of listening to a room in the presence of the sea-view:
 Instead of putting something on the sea-view:
 	say "That is not a good way to get rid of [the noun]."
 
+Instead of inserting the funnel into the sea-view:
+	try washing the funnel.
+
 Instead of inserting something into the sea-view:
 	say "That is not a good way to get rid of [the noun]."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
@@ -1,0 +1,326 @@
+Liquids by Counterfeit Monkey begins here.
+
+Use authorial modesty.
+
+Section - Liquids
+
+[We could have used a full-bore liquid extension, but there's really no reason to do so: the player is not going to be allowed to mix liquids or have partial liquid quantities, and in fact we want to encourage him to think of all objects in the game universe as atomic rather than partial and divisible.
+
+So our minimal approach to fluids just disallows a few kinds of manipulation that apply to solids, and leaves it at that.]
+
+A thing can be solid or fluid. A thing is usually solid.
+
+Instead of waving or squeezing or pulling or pushing or rubbing or turning an uncontained fluid thing:
+	say "[The noun] [don't] really respond to that kind of manipulation."
+
+Instead of taking an uncontained fluid thing (called the fluid):
+	say "[The fluid] [are] not the kind of thing [we] can just pick up and carry away."
+
+Understand "drink from [something]" as drinking.
+
+Sanity-check drinking a tap (called target tap):
+	if the player's command includes "water/from":
+		say "It may not be sanitary." instead.
+
+Sanity-check inserting something into a tap (called target tap):
+	if the player's command includes "water":
+		if target tap is switched off:
+			silently try switching on target tap;
+		try inserting the noun into the tap-water;
+		if target tap is switched on:
+			silently try switching off target tap;
+		stop the action.
+
+Before doing something other than switching on with a switched off tap:
+	abide by the don't call me water rule.
+
+This is the don't call me water rule:
+	if the player's command includes "water" and the player's command does not include "tap":
+		say "[We] can see no water here at the moment.";
+		the rule fails;
+
+Check drinking a fluid thing:
+	try eating the noun instead.
+
+Sanity-check burning a fluid thing:
+	say "Only the rare fluid is able to burn." instead.
+
+Sanity-check burning the fuel:
+	say "Let's keep your arsonist tendencies under wraps. I think they might attract attention." instead.
+
+Sanity-check burning oil:
+	say "Let's keep your arsonist tendencies under wraps. I think they might attract attention." instead.
+
+Rule for deciding whether all includes an uncontained fluid thing while taking:
+	it does not.
+
+Rule for deciding whether all includes an uncontained fluid thing while the action name part of the current action is the removing it from action:
+	it does not.
+
+Sanity-check tying an uncontained fluid to something:
+	say "[The noun] [don't] make much of an anchor point." instead.
+
+Sanity-check tying something to an uncontained fluid thing:
+	say "[The second noun] [don't] make much of an anchor point." instead.
+
+Sanity-check climbing an uncontained fluid thing:
+	say "A prominent feature of [noun] is that [they] [don't] provide much support." instead.
+
+A thing can be contained or uncontained. A thing is usually uncontained.
+
+Every turn when the player carries a fluid thing (called the puddle):
+	unless the puddle is contained:
+		move the puddle to the location;
+		say "[The puddle][one of], true to its nature, leaks out onto the ground[or] drips through our fingers onto the ground[or] drips out of our hands[at random]."
+
+Definition: a container is fluid-filled rather than dry if the first thing held by it is an uncontained fluid thing.
+
+Understand "fill [a container] with [a fluid thing]" as filling it with.
+Understand "fill [a container] with [something]" as filling it with.
+Understand "fill [something] with [a fluid thing]" as filling it with.
+Understand "fill [something] with [something]" as filling it with.
+
+Understand "pour [something] into [something]" as filling it with (with nouns reversed).
+Understand "pour [a fluid thing] into [something]" as filling it with (with nouns reversed).
+Understand "pour [something] into [a container]" as filling it with (with nouns reversed).
+Understand "pour [a fluid thing] into [a container]" as filling it with (with nouns reversed).
+
+Every turn when a fluid thing (called target) is in a pan:
+	unless the target is contained:
+		move the target to the location;
+		say "[The target] runs rapidly out through the slots of the pan."
+
+Filling it with is an action applying to two things.
+
+Check inserting something into a fluid-filled container:
+	try inserting the noun into the first thing held by the second noun instead.
+
+Check inserting something into a fluid thing (called the liquid):
+	if the liquid is washing-appropriate:
+		try washing the noun instead;
+	otherwise:
+		say "[We] don't want to get [second noun] all over [the noun]." instead.
+
+Check putting an uncontained fluid thing (called the liquid) on something:
+	if the liquid is washing-appropriate:
+		try washing the second noun instead;
+	if the second noun is a drain (called D):
+		say "[The liquid] would disappear down [the D]." instead;
+	otherwise:
+		say "[We] don't want [noun] all over [the second noun]." instead.
+
+Check putting a fluid thing on a fluid thing:
+	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
+
+Check inserting a fluid thing into a fluid thing:
+	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
+
+Sanity-check inserting an uncontained fluid thing into a container (called target):
+	unless the target is a pan:
+		try filling the second noun with the noun instead.
+
+Instead of inserting the funnel into a container which incorporates a drain:
+	try washing the funnel.
+
+Check inserting something into a container which incorporates a drain (called D):
+	say "Better not. We don't want to get [the noun] all wet." instead.
+
+Check filling a container which incorporates a drain (called D) with an uncontained fluid thing:
+	say "[The second noun] would disappear down [the D]." instead.
+
+Instead of examining a drain (called target drain):
+	say "[The target drain] is unimportant."
+
+Check filling a container with something which is not a fluid thing:
+	try inserting the second noun into the noun instead.
+
+Check filling a contained fluid thing with a fluid thing:
+	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
+
+Check filling the funnel with a fluid thing:
+	say "That would have about the same effect as pouring [the second noun] on our feet." instead.
+
+Check filling a net with a fluid thing:
+	say "That would have about the same effect as pouring [the second noun] on our feet." instead.
+
+Check filling a non-empty container with a fluid thing (called the liquid):
+	say "[The liquid] would make a mess in there." instead.
+
+Check filling it with:
+	say "[one of]I'd rather leave [the second noun] where [they] [are].[or]I don't see much point to filling something with [second noun].[at random]" instead.
+
+Check an actor washing (this is the new restrict washing to the proximity of sinks rule):
+	if the actor can touch a washing-appropriate thing:
+		do nothing;
+	otherwise:
+		if the player is the actor:
+			say "[We] [can] see no good source of fresh water for washing." (A) instead;
+		stop the action;
+
+The new restrict washing to the proximity of sinks rule is listed instead of the restrict washing to the proximity of sinks rule in the check washing rulebook.
+
+Check an actor bathing (this is the new restrict baths to bathrooms rule):
+	if the actor can touch a washing-appropriate thing:
+		do nothing;
+	otherwise:
+		if the player is the actor:
+			say "[We] [can] see no good source of fresh water for washing." (A) instead;
+		stop the action;
+
+The new restrict baths to bathrooms rule is listed instead of the restrict baths to bathrooms rule in the check bathing rulebook.
+
+
+Understand "wash [something] in/with [something]" as washing it with.
+Understand "clean [something] in/with [something]" as washing it with.
+Understand "wet [something] in/with [something]" as washing it with.
+
+Washing it with is an action applying to two things.
+
+Instead of washing something with something that is not fluid:
+	if the player's command includes "in" and the second noun is a container:
+		if the second noun contains a fluid thing (called the liquid):
+			try washing the noun with the liquid;
+		otherwise:
+			try washing the noun;
+	otherwise:
+		if the second noun is washing-appropriate:
+			try washing the noun;
+		otherwise:
+			say "How would that even work?".
+
+Check washing something with a fluid thing (called the liquid):
+	unless the liquid is washing-appropriate:
+		say "I doubt [the second noun] would make [the noun] much cleaner." instead;
+	otherwise:
+		try washing the noun instead.
+
+Definition: a thing is washing-appropriate:
+	if it is fountain-water:
+		yes;
+	if it is soap:
+		yes;
+	if it is sea-view:
+		yes;
+	if it is distant-sea-view:
+		yes;
+	if it is tap-water:
+		yes;
+	if it is a tap:
+		yes;
+	if it incorporates a tap:
+		yes.
+
+Section - Taps and washing
+
+[Loosely based on rules from Part 3 - Flowing Water in Modern Conveniences by Emily Short]
+
+The tap-water is fluid scenery.
+	The indefinite article is "some". The printed name is "water". The description is "Ordinary tap water. Perhaps with a hint of green precipitate."
+	Understand "water/precipitate" as the tap-water.
+	Instead of taking the tap-water, say "[We] can't, not having webbed fingers."
+	Instead of drinking the tap-water, say "It might not be sanitary."
+	The scent-description of the tap-water is "wet metal".
+
+The heft of a sink is 5.
+
+Instead of examining something (called target sink) which incorporates a switched on tap (called target tap):
+	if description of target sink is not empty:
+		say "[description of target sink][paragraph break]";
+	say "Water pours from [the target tap]."
+
+Before printing the name of a drain (called target) (this is the drain identification rule):
+	if target is part of something (called target sink) which is not the galley sink:
+		say "[random thing which includes the target] " (A).
+
+Does the player mean doing something to the tap-water:
+	it is very likely.
+
+Does the player mean doing something to a tap:
+	it is very unlikely.
+
+Does the player mean switching off the letter-remover:
+	it is very unlikely.
+
+Setting action variables for filling something with a switched on tap (this is the divert filling with taps rule):
+	now the second noun is the tap-water.
+
+Setting action variables for switching on when the noun is tap-water (this is the divert TURN OFF WATER rule):
+	if some switched off taps (called target taps) are marked-visible:
+		now the noun is the target taps;
+	otherwise if some taps (called target taps) are marked-visible:
+		now the noun is the target taps.
+
+Setting action variables for switching off when the noun is tap-water (this is the divert TURN ON WATER rule):
+	if some switched on taps (called target taps) are marked-visible:
+		now the noun is the target taps;
+	otherwise if some taps (called target taps) are marked-visible:
+		now the noun is the target taps.
+
+Sanity-check switching on a switched on tap:
+	if there is a switched off tap (called target tap) enclosed by location:
+		try switching on target tap instead.
+
+Sanity-check switching off a switched off tap:
+	if there is a switched on tap (called target tap) enclosed by location:
+		try switching off target tap instead.
+
+Before switching on a switched off tap (called target tap):
+	let the target sink be a random container which incorporates the target tap;
+	[This works because we only allow the soap and derivates in sinks]
+	if there is a non-empty sink (called soap-sink) in location and there is a thing (called soap-thing) which is not tap-water in soap-sink:
+		now soap-thing is in target sink;
+	unless the target sink is empty:
+		say "As we turn on the water, [the list of things in target sink with definite articles] washes down the drain.";
+		repeat with item running through things in target sink:
+			if item is the soap or item is proffered by the soap:
+				move item to repository;
+				move soap to soap dispenser;
+			otherwise:
+				now the item is nowhere;
+		move tap-water to target sink;
+		now target tap is switched on;
+		stop the action;
+
+A last description-concealing rule (this is the new running things aren't scenery rule):
+	now every open refrigerator in location is marked for listing;
+	now a random switched on tap enclosed by location is marked for listing.
+
+The new running things aren't scenery rule is listed instead of the running things aren't scenery rule in the description-concealing rules.
+
+A first rule for writing a paragraph about a switched on tap:
+	let S be the number of (sinks incorporating a switched on tap) enclosed by location;
+	let B be the number of (baths incorporating a switched on tap) enclosed by location;
+	if B is 0 and S is at least 2:
+		say "There are [S in words] sink taps running.[paragraph break]";
+		the rule succeeds;
+	if B is 1 and S is 1:
+		say "[The random (switched on tap which is part of a bath) enclosed by location] and [the random (switched on tap which is part of a sink) enclosed by location] are both running.[paragraph break]";
+		the rule succeeds;
+	say "[The list of switched on taps enclosed by location] [are] running.[paragraph break]"
+
+Last carry out an actor switching on a tap (called the target tap) (this is the move water supply rule):
+	move tap-water to a random container which incorporates the target tap.
+
+The standard report switching taps on rule response (A) is "[We] [turn] on [the noun]. Water flows into the [random container which incorporates the noun]."
+
+The standard report switching taps off rule response (A) is "[We] [turn] off [the noun]. The water drains away."
+
+Check an actor washing (this is the new block washing rule):
+	if the noun is fluid:
+		 say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead;
+	if the noun is edible:
+		say "That would not make [the noun] more appet[izing]." instead;
+	if the player is the actor:
+		say "[regarding nothing]It [don't] seem worth the bother to wash [the noun]." (A) instead;
+	stop the action.
+
+The new block washing rule is listed instead of the block washing rule in the check washing rulebook.
+
+Last carry out an actor switching off a tap (called target tap) (this is the remove water supply rule):
+	if there is a marked-visible switched on tap which is part of a container (called target container):
+		move tap-water to target container;
+	otherwise:
+		now tap-water is nowhere.
+
+
+Liquids ends here.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
@@ -230,7 +230,10 @@ Instead of examining something (called target sink) which incorporates a tap (ca
 		say "Water pours from [the target tap].";
 	otherwise:
 		if description of target sink is empty:
-			say "[We] see nothing special about [the target sink]."
+			if target sink is empty:
+				say "[We] see nothing special about [the target sink].";
+			otherwise:
+				say "In [the target sink] [is-are a list of things *in target sink]."
 
 Before printing the name of a drain (called target) (this is the drain identification rule):
 	if target is part of something (called target sink) which is not the galley sink:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
@@ -223,10 +223,14 @@ The tap-water is fluid scenery.
 
 The heft of a sink is 5.
 
-Instead of examining something (called target sink) which incorporates a switched on tap (called target tap):
+Instead of examining something (called target sink) which incorporates a tap (called target tap):
 	if description of target sink is not empty:
 		say "[description of target sink][paragraph break]";
-	say "Water pours from [the target tap]."
+	if target tap is switched on:
+		say "Water pours from [the target tap].";
+	otherwise:
+		if description of target sink is empty:
+			say "[We] see nothing special about [the target sink]."
 
 Before printing the name of a drain (called target) (this is the drain identification rule):
 	if target is part of something (called target sink) which is not the galley sink:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -2162,7 +2162,7 @@ Persuasion rule for asking the pirate-crew to try doing something:
 	otherwise:
 		say "They mumble defiantly." instead.]
 
-Instead of washing the pirate-crew:
+Sanity-check washing the pirate-crew:
 	say "Heaven knows they need it, but they don't look terribly cooperative."
 
 Instead of showing the spot to the pirate-crew:
@@ -2839,12 +2839,7 @@ Sanity-check burning the sap-liquid:
 	say "I think some resins might burn when dry, but I'm not sure that applies here, and in any case it wouldn't help." instead.
 
 Instead of squeezing the sap-dispenser:
-	if sap-liquid is in the sap-dispenser:
-		let target be a random sink in the location;
-		say "[We] give the dispenser a squeeze and it deposits some sap in the sink [--] just viscous enough not to drain away instantly.";
-		move the sap-liquid to the target;
-	otherwise:
-		say "This time nothing much comes out."
+	say "Nothing much comes out."
 
 The satin-pin is wearable. The printed name of the satin-pin is "satin pin". Understand "satin" or "satin pin" as the satin-pin. Understand "pin" as the satin-pin when the pin is marked invisible. The description of the satin-pin is "It's a little brooch, probably not very valuable, bearing a blue and white satin rosette. The edges of the rosette have yellowed with age, and there is a blob of glue at the center that must once have held some additional decoration."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -367,6 +367,13 @@ Carry out listing edible:
 	sort N;
 	say "[N]".
 
+Understand "list uncontained" as listing uncontained.  Listing uncontained is an action out of world.
+
+Carry out listing uncontained:
+	let N be the list of uncontained fluid things;
+	sort N;
+	say "[N]".
+
 Understand "list components" as listing components. Listing components is an action out of world.
 
 Carry out listing components:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -344,7 +344,7 @@ Check waving the letter-remover at a room creating the letter-remover:
 	say "[The letter-remover] is powerless to make [the second noun] into anything called '[disappointment text]', but perhaps this is to be expected considering the size of the target. The device is after all a mere portable device with limited resources."
 
 Check waving the letter-remover at something (called target) creating an uncontained fluid thing (called the liquid):
-	if the target is in a container (called target holder) and the number of things in target holder is greater than 1:
+	if the target is in a container (called target holder) and the number of things in target holder is greater than 1 and target holder is not the synthesizer:
 		say "[The liquid] would make a real mess in [the target holder]." instead.
 
 Check waving the letter-remover at a room creating something which is not the letter-remover:
@@ -1265,7 +1265,7 @@ Sanity-check putting the restoration gel on something irretrievable:
 
 Before putting the restoration gel on something which is in a container (called the box):
 	if the second noun is proffered by an uncontained fluid thing (called the liquid):
-		if the number of things in the box is greater than 1 or the number of things proffered by the second noun is greater than 1:
+		if the number of things in the box is greater than 1 or the number of things proffered by the second noun is greater than 1 and the box is not the synthesizer:
 			say "[The liquid] would make a real mess in [the box]." instead.
 
 Before putting the restoration gel on something which is in the backpack:
@@ -1519,7 +1519,7 @@ Sanity-check shooting the loaded anagramming gun with the loaded anagramming gun
 	say "It is impossible to aim the gun at itself." instead.
 
 Check shooting the pills with the loaded anagramming gun:
-	if the pills are in a container (called the box) and the number of things in the box is greater than 1:
+	if the pills are in a container (called the box) and the number of things in the box is greater than 1 and the box is not the synthesizer:
 		say "The spill would make a real mess in [the box]." instead.
 
 Check shooting something with the loaded anagramming gun:
@@ -1607,7 +1607,7 @@ Sanity-check shooting something irretrievable with the restoration-gel rifle:
 
 Before shooting something which is in a container (called the box) with the restoration-gel rifle:
 	if the noun is proffered by an uncontained fluid thing (called the liquid):
-		if the number of things in the box is greater than 1 or the number of things proffered by the noun is greater than 1:
+		if the number of things in the box is greater than 1 or the number of things proffered by the noun is greater than 1 and the box is not the synthesizer:
 			say "[The liquid] would make a real mess in [the box]." instead.
 
 [Because it's possible to change something into an object that becomes fixed in place in the backpack, or too heavy to move...]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -343,6 +343,10 @@ Check waving the letter-remover device at something (this is the checking for da
 Check waving the letter-remover at a room creating the letter-remover:
 	say "[The letter-remover] is powerless to make [the second noun] into anything called '[disappointment text]', but perhaps this is to be expected considering the size of the target. The device is after all a mere portable device with limited resources."
 
+Check waving the letter-remover at something (called target) creating an uncontained fluid thing (called the liquid):
+	if the target is in a container (called target holder) and the number of things in target holder is greater than 1:
+		say "[The liquid] would make a real mess in [the target holder]." instead.
+
 Check waving the letter-remover at a room creating something which is not the letter-remover:
 	abide by the dangerous destruction rules for the second noun;
 	[abide by the dangerous construction rules for the generated object.]
@@ -1259,6 +1263,11 @@ Sanity-check putting the restoration gel on something irretrievable:
 
 [Because it's possible to change something into an object that becomes fixed in place in the backpack, or too heavy to move...]
 
+Before putting the restoration gel on something which is in a container (called the box):
+	if the second noun is proffered by an uncontained fluid thing (called the liquid):
+		if the number of things in the box is greater than 1 or the number of things proffered by the second noun is greater than 1:
+			say "[The liquid] would make a real mess in [the box]." instead.
+
 Before putting the restoration gel on something which is in the backpack:
 	try taking the second noun;
 	if the player does not carry the second noun:
@@ -1509,6 +1518,10 @@ Sanity-check shooting something irretrievable with the loaded anagramming gun:
 Sanity-check shooting the loaded anagramming gun with the loaded anagramming gun:
 	say "It is impossible to aim the gun at itself." instead.
 
+Check shooting the pills with the loaded anagramming gun:
+	if the pills are in a container (called the box) and the number of things in the box is greater than 1:
+		say "The spill would make a real mess in [the box]." instead.
+
 Check shooting something with the loaded anagramming gun:
 	let initial key be the anagram key of the noun;
 	now detritus is the noun;
@@ -1591,6 +1604,11 @@ The description of the restoration-gel rifle is "A rifle that shoots pellets of 
 Sanity-check shooting something irretrievable with the restoration-gel rifle:
 	unless the noun is the tub or the noun is original:
 		abide by the don't change irretrievable rules for the noun.
+
+Before shooting something which is in a container (called the box) with the restoration-gel rifle:
+	if the noun is proffered by an uncontained fluid thing (called the liquid):
+		if the number of things in the box is greater than 1 or the number of things proffered by the noun is greater than 1:
+			say "[The liquid] would make a real mess in [the box]." instead.
 
 [Because it's possible to change something into an object that becomes fixed in place in the backpack, or too heavy to move...]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -1387,7 +1387,23 @@ When play begins (this is the toilet postures rule):
 	now every toilet allows seated;
 	now every toilet allows standing.
 
-Understand "wash hands" or "wash up" as a mistake ("[if a sink is in the location][We] briskly wash up[otherwise]There's no sink here[end if].").
+Understand "wash my/our/-- hands/face/up" as washing hands. Washing hands is an action applying to nothing.
+
+Understand "wash my/our/-- hands/face/up in/with [washing-appropriate thing]" as washing hands in. Washing hands in is an action applying to one thing.
+
+Carry out washing hands in:
+	try washing hands instead.
+
+Carry out washing hands:
+	if the player can touch a washing-appropriate thing (called the target):
+		if the target is a switched off tap:
+		[This is to remove any things we might have put in the sink or bath.]
+			silently try switching on the target;
+		say "[We] briskly wash up.";
+		if the target is a switched on tap:
+			silently try switching off the target;
+	otherwise:
+		say "There's nothing here to wash in."
 
 Sanity-check washing a person who is not the player:
 	if the noun is an animal:
@@ -1675,82 +1691,7 @@ When play begins (this is the search engines rule):
 
 Chapter 2 - Substances
 
-Section 1 - Liquids
-
-[We could have used a full-bore liquid extension, but there's really no reason to do so: the player is not going to be allowed to mix liquids or have partial liquid quantities, and in fact we want to encourage him to think of all objects in the game universe as atomic rather than partial and divisible.
-
-So our minimal approach to fluids just disallows a few kinds of manipulation that apply to solids, and leaves it at that.]
-
-A thing can be solid or fluid. A thing is usually solid.
-
-Instead of waving or squeezing or pulling or pushing or rubbing or turning a fluid thing:
-	say "[The noun] [don't] really respond to that kind of manipulation."
-
-Sanity-check drinking a solid thing:
-	say "[The noun] [aren't] liquid." instead.
-
-Check drinking a fluid thing:
-	try eating the noun instead.
-
-Sanity-check burning a fluid thing:
-	say "Only the rare fluid is able to burn." instead.
-
-Sanity-check burning the fuel:
-	say "Let's keep your arsonist tendencies under wraps. I think they might attract attention." instead.
-
-Sanity-check burning oil:
-	say "Let's keep your arsonist tendencies under wraps. I think they might attract attention." instead.
-
-Rule for deciding whether all includes an uncontained fluid thing while taking:
-	it does not.
-
-Rule for deciding whether all includes an uncontained fluid thing while the action name part of the current action is the removing it from action:
-	it does not.
-
-Sanity-check tying an uncontained fluid to something:
-	say "[The noun] [don't] make much of an anchor point." instead.
-
-Sanity-check tying something to an uncontained fluid thing:
-	say "[The second noun] [don't] make much of an anchor point." instead.
-
-Sanity-check climbing an uncontained fluid thing:
-	say "A prominent feature of [noun] is that [they] [don't] provide much support." instead.
-
-A thing can be contained or uncontained. A thing is usually uncontained.
-
-Every turn when the player carries a fluid thing (called the puddle):
-	unless the puddle is contained:
-		move the puddle to the location;
-		say "[The puddle][one of], true to its nature, leaks out onto the ground[or] drips through our fingers onto the ground[or] drips out of our hands[at random]."
-
-[TODO: It would be nice to have a generic response to trying to insert things into a liquid.]
-
-Understand "fill [a container] with [a fluid thing]" as filling it with.
-Understand "fill [a container] with [something]" as filling it with.
-Understand "fill [something] with [a fluid thing]" as filling it with.
-Understand "fill [something] with [something]" as filling it with.
-
-Understand "pour [something] into [something]" as filling it with (with nouns reversed).
-Understand "pour [a fluid thing] into [something]" as filling it with (with nouns reversed).
-Understand "pour [something] into [a container]" as filling it with (with nouns reversed).
-Understand "pour [a fluid thing] into [a container]" as filling it with (with nouns reversed).
-
-Filling it with is an action applying to two things.
-
-Sanity-check filling a container with something which is not a fluid thing:
-	try inserting the second noun into the noun instead.
-
-Check filling a contained fluid with a fluid thing:
-	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
-
-Check filling the funnel with a fluid thing:
-	say "That would have about the same effect as pouring [the second noun] on our feet." instead.
-
-Check filling it with:
-	say "[one of]I'd rather leave [the second noun] where [they] [are].[or]I don't see much point to filling containers with things.[at random]" instead.
-
-
-Section 2 - Vegetables
+Section 1 - Vegetables
 
 A vegetable is a kind of thing. The description of a vegetable is usually "Some leafy greens that might make an okay side salad, if [we] were feeling hungry." A vegetable is usually edible.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/actions on multiple objects.i7x
@@ -105,6 +105,8 @@ Definition: a thing is single put on only:
 		yes;
 	if it is enclosed by the display case:
 		yes;
+	if it is enclosed by a car and the location is traffic circle:
+		no;
 	if it is not enclosed by the player and the location is privately-controlled:
 		yes.
 
@@ -196,7 +198,7 @@ This is the fake put on rule:
 	now dummy-object is nowhere;
 	abide by the cancel multiple rule.
 
-Dummy-object is a proper-named thing. The printed name of dummy-object is "[if location is privately-controlled or the second noun is fluid]our things[otherwise][one of]stuff[or]things[at random][end if]".
+Dummy-object is a proper-named thing. The printed name of dummy-object is "[if location is privately-controlled or the second noun is fluid or the second noun incorporates a tap]our [end if][one of]stuff[or]things[at random]".
 
 This is the cancel multiple rule:
 	alter the multiple object list to {};
@@ -213,7 +215,11 @@ Definition: a thing is single insert only:
 		yes;
 	if it is a drain:
 		yes;
+	if it incorporates a drain:
+		yes;
 	if it is a freezer compartment:
+		yes;
+	if it is fluid-filled:
 		yes;
 	if it is a box listed in the Table of snarky containers:
 		yes;


### PR DESCRIPTION
This is some improved behavior of fluid things, sinks, taps and washing. I've tried to stay true the spirit of this original comment at the beginning of the liquids section:

> We could have used a full-bore liquid extension, but there's really no reason to do so: the player is not going to be allowed to mix liquids or have partial liquid quantities, and in fact we want to encourage him to think of all objects in the game universe as atomic rather than partial and divisible.

However, I've also tried to aid the suspension of disbelief a little. It is no longer allowed to put things in sinks or showers or other things with drains and faucets, nor to pick up uncontained fluid things and put them in containers or on supporters. I don't know if this was ever deliberately possible before, and I don't think this will ever cause the player any trouble in practice, but if it should, most liquids can be easily transformed into solid things.

Unfortunately this does not fix #34, which is caused by our old friend the "plural token" bug, but it does address another issue mentioned in Emily's bug fix list:

> The sink/tap behaves very strangely, turning on the tap doesn't make
> water, if you x the sink, but turning on the water does.

EDIT: Now fixes #34 too, with a slightly gross hack.