### PR TITLE
Consistent go to-refusal messages

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -1080,6 +1080,9 @@ A diorama table is fixed in place in Heritage Corner. It is a supporter. The ini
 
 The description of the diorama table is "The patriotic scene is set against the backdrop of the Bureau's buildings ca. 1895, where the committee first met, but the historians have included a bit of the building exterior to show that the meetings were conducted under army guard. The writing of dictionaries has not always been bloodless[if the army is not on the diorama table and the members are not on the diorama table]. Both army and members are missing[otherwise if the army is not on the diorama table]. The army has been removed[otherwise if the members are not on the diorama table and the member is on the diorama table]. The members have been reduced to a single [member][otherwise if the members are not on the diorama table]. The members have been removed[end if].". Understand "backdrop" or "setting" or "buildings" or "bureau" or "bureau's" or "building" or "scenery" as the diorama table when the location is Heritage Corner.
 
+Does the player mean approaching the Rotunda:
+	it is very likely.
+
 Does the player mean finding the diorama table:
 	it is very unlikely.
 
@@ -1798,7 +1801,7 @@ To say prayer response:
 
 The gift-shop-exterior is a facade in New Church. It is scenery. It fronts south. The description is "[We] can't really see it from here; I just know that it is back there, from previous visits, though decently screened from the main body of the church."  Understand "shop" or "gift shop" or "narthex" as the gift-shop-exterior. The printed name is "gift shop".
 
-The Cathedral Gift Shop is south of the New Church. Understand "narthex" as the cathedral gift shop. It is indoors. The description is "This area used to be a sort of antechamber where the priests and choir might gather for processions into the church, but it has now been done over for retail purposes. This is one of several schemes to make the New Church pay for its own upkeep: a problem is that people somehow feel everything associated with a church ought to be free, including lunchtime concerts, potluck suppers, and Thursday-night lecture series."
+The Cathedral Gift Shop is south of the New Church. Understand "narthex" and "giftshop" as the cathedral gift shop. It is indoors. The description is "This area used to be a sort of antechamber where the priests and choir might gather for processions into the church, but it has now been done over for retail purposes. This is one of several schemes to make the New Church pay for its own upkeep: a problem is that people somehow feel everything associated with a church ought to be free, including lunchtime concerts, potluck suppers, and Thursday-night lecture series."
 
 The gift-shop counter is a scenery supporter in the Cathedral Gift Shop. The description is "The usual arrangement for making purchases."
 
@@ -1926,20 +1929,20 @@ Instead of approaching Old City Walls when the backpack is not handled:
 	say high-street refusal instead.]
 
 
-Instead of going to Monumental Staircase when the backpack is not handled:
+[ Instead of going to Monumental Staircase when the backpack is not handled:
 	say high-street refusal.
 
 Instead of approaching Monumental Staircase when the backpack is not handled:
-	say high-street refusal.
+	say high-street refusal.]
 
 To say high-street refusal:
 	say "[one of]That way will take us away from the cinema, and I'd like to retrieve our things first.[or]Er, before we strike out into the rest of town, could we get my backpack from the cinema?[or]Look, I'm not ready to leave this part of town until we've retrieved my stuff from the cinema. It might not seem important to you, but it's my whole reason for leaving the island, and I'm not going without it.[stopping]".
 
-Instead of going to Monumental Staircase when the secret-plans are not handled:
+[ Instead of going to Monumental Staircase when the secret-plans are not handled:
 	say plans-search refusal.
 
 Instead of approaching Monumental Staircase when the secret-plans are not handled:
-	say plans-search refusal.
+	say plans-search refusal. ]
 
 To say plans-search refusal:
 	say "I think we'd better get your things from the hostel before we leave this part of town, don't you?".

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -247,6 +247,8 @@ Understand "unmonkey" as unmonkeying. Unmonkeying is an action out of world.
 
 Carry out unmonkeying:
 	now Slango is seen;
+	now the backpack is handled;
+	now the secret-plans are seen;
 	now the Counterfeit Monkey is visited. [This turns off certain movement restrictions that prevent the player from visiting most of the map when the player hasn't been to the Counterfeit Monkey first.]
 
 [The Consulting-Slango scene can come back and bite us again if we skip to the end of the game and meet Slango for the first time, thus restricting our movement.]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -631,17 +631,108 @@ Sanity-check approaching a room (called target):
 
 The room-restriction rules are an object-based rulebook.
 
-A room-restriction rule for a southern room:
+A first room-restriction rule for a room (called destination) that is not Starting Area:
+	if backpack is not handled:
+		say high-street refusal;
+		rule fails;
+	if secret-plans are not seen:
+		say plans-search refusal;
+		rule fails.
+
+Definition: a room is Starting Area:
+	if it is Monumental Staircase:
+		no;
+	if it is Back Alley:
+		yes;
+	if it is Sigil Street:
+		yes;
+	if it is Ampersand Bend:
+		yes;
+	if it is New Church:
+		yes;
+	if it is Cathedral Gift Shop:
+		yes;
+	if it is Church Garden:
+		yes;
+	if it is Cinema Lobby:
+		yes;
+	if it is The Screening Room:
+		yes;
+	if it is Projection Booth:
+		yes;
+	if it is Hostel:
+		yes;
+	if it is Dormitory Room:
+		yes;
+	if it is in Open-Air:
+		yes.
+
+A room-restriction rule for a southern room (called destination):
 	if the Counterfeit Monkey is unvisited:
 		say "Don't [we] have an appointment at the Counterfeit Monkey? [We] should be heading northeast up Deep Street.";
 		rule fails;
 	if Slango is not seen and Counterfeit Monkey is visited:
 		say "That would take us more towards my part of the world, not help us find Slango.";
+		rule fails;
+	if destination is legend-restricted:
+		say square-refusal;
 		rule fails.
+
+Definition: a room is legend-restricted:
+	if legend is introduced:
+		no;
+	if it is Palm Square:
+		yes;
+	if it is My Apartment:
+		yes;
+	if it is Apartment Bathroom:
+		yes;
+	if it is Babel Café:
+		yes;
+	if it is in Campus:
+		yes.
+
+A room-restriction rule for a before-security-door room when cold dilemma has happened:
+	say "[if Precarious Perch is visited][We] don't know how to get there from here[otherwise]The way through the Bureau will be guarded. If [we] [are] going to get out, it will have to be by some back way[end if].";
+	the rule fails;
+
+Definition: a room is before-security-door:
+	if it is nautical:
+		no;
+	if it is Precarious Perch:
+		no;
+	if it is Abandoned Shore:
+		no;
+	if it is Open Sea:
+		no;
+	if it is Beside Slango's Ship:
+		no;
+	if it is Private Solarium:
+		no;
+	if it is Personal Apartment:
+		no;
+	if it is Tunnel through Chalk:
+		no;
+	if it is not in Official Grounds:
+		yes;
+	if it is The Antechamber:
+		yes;
+	if it is Rotunda:
+		yes;
+	if it is Tools Exhibit:
+		yes;
+	if it is All-Purpose Office:
+		yes;
+	if it is Bureau Hallway:
+		yes;
+	if it is Bureau Basement South:
+		yes;
+	if it is Bureau Basement Middle:
+		yes.
 
 A room-restriction rule for Tall Street when Counterfeit Monkey is unvisited:
 	say "Don't [we] have an appointment at the Counterfeit Monkey? [We] should be heading northeast up Deep Street.";
-	rule fails;
+	rule fails.
 
 A room-restriction rule for Wonderland when Brock-argument has not happened:
 	say "Best to start looking for Brock where we know he went: the equipment testing room.";


### PR DESCRIPTION
Give the same complaint about not having the backpack or the plans when we try to leave the starting area, even if we try to GO TO MONUMENT GREEN or anything else that looks interesting on the map.

There are a couple of other situations where the game stops us at a particular room with a refusal message, while not giving the same message when trying to go to the rooms beyond it.

Basically this is a) to make the game refuse right away when we try to go somewhere not allowed, rather than walking halfway and then giving the refusal message, and b) to give the same refusal message no matter what room behind the "hindrance" we try to go to.