### PR TITLE
New conversation

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -438,7 +438,6 @@ whether the Britishizing goggles seem interesting is a demonstration quip.
  The reply is "'[if the current interlocutor is tourist]They look like aviator goggles to me[otherwise if the current interlocutor is native]I thought those had gone out of style[otherwise]Are you sure you ought to be showing those off? Someone might take an interest[end if].'"
  It is repeatable.
  It is background-information.
-Understand "if" as whether the Britishizing goggles seem interesting.
 
 whether the Origin Paste seems interesting is a demonstration quip.
  It mentions origin paste.
@@ -446,7 +445,6 @@ whether the Origin Paste seems interesting is a demonstration quip.
  The reply is "'[one of]Smells[or]Looks[at random] like soap,' [the current interlocutor] [comment].".
  It is repeatable.
  It is background-information.
-Understand "if" as Origin Paste seems interesting.
 
 Instead of a criminal person discussing whether Origin Paste seems interesting:
 	say "[The current interlocutor] [open] [their] mouth, then [think] better of answering and just shrugs non-committally."
@@ -457,7 +455,6 @@ whether the letter-remover means anything is a weakly-phrased demonstration quip
  The reply is "[one of]'I hope you're licensed to carry that.'[or]'It looks pretty ordinary to me.'[or]'What am I supposed to be noticing? It looks like it's set to [current setting of the letter-remover].'[at random]".
  It is repeatable.
  It is background-information.
-Understand "if" as whether the letter-remover means anything.
 
 Availability rule for whether the letter-remover means anything:
 	if the current interlocutor is Professor Brown, it is off-limits.
@@ -467,14 +464,12 @@ whether the oil seems interesting is a demonstration quip.
  The comment is "'Care for some motor oil?' [we] ask [the current interlocutor]."
  The reply is "'[awkward no].' No wonder, really. The stuff is dirt cheap.".
  It is background-information.
-Understand "if" as whether the oil seems interesting.
 
 whether the monocle seems interesting is a demonstration quip.
  It mentions monocle.
  The comment is "[demonstration of monocle]".
  The reply is "[one of]'Fancy,' remarks [the current interlocutor]. 'I've only ever seen those being worn by authenticators.'[or]'Very nice,' says [the current interlocutor], though apparently a bit bored.[or]'Do you go around town showing that to everyone? Because I wouldn't.'[or]'Yes,' says [the current interlocutor].[or]This attracts disappointingly little interest.[stopping]".
  It is background-information.
-Understand "if" as whether the monocle seems interesting.
 
 Instead of the secretary discussing whether the monocle seems interesting:
 	say "She looks, then frowns. 'You shouldn't have that,' she remarks, in a voice of cold disapproval. 'In fact[--]'
@@ -705,7 +700,7 @@ Availability rule for whether car be fixed:
 
 whether car be fixed is a questioning quip.
 	The printed name is "whether the car is fixed".
-	Understand "is" or "if" as whether car be fixed.
+	Understand "is" as whether car be fixed.
 	It mentions oil1, oil2.
 	The comment is "'Is the car fixed now?' we ask."
 	The reply is "'The oil is in,' the mechanic says[if at least one car is fueled]. 'Should run all right[otherwise]. 'Might be it's out of fuel, though[end if].'".
@@ -759,7 +754,6 @@ whether the oil will work is an unlisted offering quip.
  The reply is "'Should do,' he says. Rolling up his sleeves, he goes to work on the car. There is no small amount of banging and muttering, but finally he stands back and announces that he believes it is now in working condition."
  It indirectly-follows why the car does not run.
  It quip-supplies the mechanic.
-Understand "if" as whether the oil will work.
 
 
 
@@ -1043,7 +1037,7 @@ Carry out the farmer discussing buy the asparagus:
 
  whether he dons overalls is a questioning quip.
  The printed name is "whether he wears overalls". The true-name is "whether he dons overalls".
- Understand "wears" or "if" as whether he dons overalls.
+ Understand "wears" as whether he dons overalls.
  It mentions Fashion.
  The comment is "'Say, do you ever wear overalls?' we ask pertly.".
  The reply is "He shifts his jaw a little to one side. [when distrustful]'No,' he says curtly. Evidently we aren't his fav[our]ite people. Person. Whatever.[at other times]'I used to, but my wife took a dislike,' he says.[end when]".
@@ -1831,7 +1825,7 @@ Kate removes the map from its case and packs it up carefully for us.".
 
 whether she hath seen Brock-man is a questioning quip.
  The printed name is "whether she has seen Brock".
- Understand "if" or "has" or "brock" as whether she hath seen Brock-man.
+ Understand "has" or "brock" as whether she hath seen Brock-man.
  It mentions Brock.
  The comment is "'Have you seen a man [--] maybe this morning [--] about this height, dark hair, very blue eyes, kind of cocky?'"
 The reply is "There's a light of recognition. 'Yes, he was in. A friend of my boss. He visited the shop and sold us [if Kate recollects buy the slangovia map]that map you just purchased[otherwise]a map he happened to have with him[end if]. Then they left, together. I believe there was some discussion of seeing a demonstration[casually queue recommend-help].'"
@@ -1869,7 +1863,6 @@ whether Brock-man seemed upset is a questioning quip.
 Cryptic. Perhaps he was posing as a researcher? But we can't very well ask, not if we're supposed to be a friend of his."
  It indirectly-follows whether she hath seen Brock-man.
  It quip-supplies Kate.
-Understand "if" as whether Brock-man seemed upset.
 
 recommend-help is an NPC-directed quip.
  The reply is "'If your friend is missing, you could report him to the Bureau, you know,' she says. 'I believe they keep close tabs on academic and research visitors. They may well know where he is.'
@@ -2024,7 +2017,6 @@ offer the ticket redundantly is an unlisted demonstration quip.
  It quip-supplies the mechanic.
  It is background-information.
  It indirectly-follows when the movie starts.
-Understand "if" as  whether the clock helps.
 
 [ where he bought the watch is a questioning quip.
  It mentions watch, salespeople.
@@ -2055,18 +2047,16 @@ whether he likes his job is a questioning quip. The comment is "'Do you enjoy be
  The reply is "He looks taken aback, but makes a surprising recovery. 'Yeah,' he says. 'Yeah, I do. I think it's a job with a real future.'".
  It quip-supplies the ticket-taker.
  It is background-information.
-Understand "if" as whether he likes his job.
 
 whether crime could ever be justified is a performative quip. The comment is "'Hypothetically speaking, do you think a crime could ever be justified?'".
  It mentions crime, legislation, bureau.
  The reply is "'Uh, no,' he says. 'Because if it's justified, it's not a crime. Like: if you kill someone in self-def[ense], that's justified, but it's not a crime, so you won't have to go to jail.'".
  It quip-supplies the ticket-taker.
  It is background-information.
-Understand "if" as whether crime could ever be justified.
 
 whether the government seems just is a questioning quip.
  The printed name is "whether the government is just". The true-name is "whether the government seems just".
- Understand "if" or "is" as whether the government seems just.  The comment is "'Do you think the government is just?'".
+ Understand "is" as whether the government seems just.  The comment is "'Do you think the government is just?'".
  It mentions bureau, legislation.
  The reply is "'What, here? Of course. We had universal suffrage before lots of places, right?' he says, counting off on his fingers. '1877. And we never had slavery. Plus there is very little poverty and there's a high standard of living. Good health care. No complaints here.'".
  It quip-supplies the ticket-taker.
@@ -2074,7 +2064,7 @@ whether the government seems just is a questioning quip.
 
 whether immigration laws seem fair is a performative quip.
  The printed name is "whether immigration laws are fair". The true-name is "whether immigration laws seem fair".
- Understand "if" or "are" as whether immigration laws seem fair.  The comment is "'Do you think our immigration laws are fair?'".
+ Understand "are" as whether immigration laws seem fair.  The comment is "'Do you think our immigration laws are fair?'".
  It mentions immigration, legislation, bureau.
  The reply is "'They seem like they're working,' he says. 'I don't really give that kind of thing a lot of thought, but, I've never met someone who seemed like they shouldn't have been let in, you know?'".
  It quip-supplies the ticket-taker.
@@ -2085,7 +2075,7 @@ Definition: whether he hath ever been in trouble alongside law is civic:
 
 whether he hath ever been in trouble alongside law is a performative quip.
  The printed name is "whether he has ever been in trouble with the law". The true-name is "whether he hath ever been in trouble alongside law".
- Understand "if" or "has" or "with" as whether he hath ever been in trouble alongside law.  The comment is "'Have you ever had any run-ins with the law?'".
+ Understand "has" or "with" as whether he hath ever been in trouble alongside law.  The comment is "'Have you ever had any run-ins with the law?'".
  It mentions security, legislation, crime.
  The reply is "'That's kind of none of your business, isn't it?'".
  It quip-supplies the ticket-taker.
@@ -2322,7 +2312,7 @@ The reply is "'I'm sorry, those with passes only,' she says, before waving us ou
 
  whether we can hath the scope is a questioning quip.
  The printed name is "whether we can have the scope". The true-name is "whether we can hath the scope".
- Understand "if" or "have" as whether we can hath the scope.
+ Understand "have" as whether we can hath the scope.
  It mentions Regulation Authentication Scope.
  The comment is "'You wouldn't be willing to part with that authentication scope, just for a moment?' we suggest, in a wheedling tone of voice[one of]. All right, even I can see that this isn't going to work[or][stopping].".
  The reply is "'It is official issue,' she snaps. [set distrustful]'Civilians aren't allowed to have these.'".
@@ -2357,7 +2347,6 @@ An availability rule for where to get a pass:
  The comment is "'This must be a good job,' we say[one of], in our best making-friendly-conversation way[or][stopping]. 'Getting to meet lots of new people. Access to all the bureau toys.'".
  The reply is "'They never let me try any of the good equipment,' she says, with surprising bitterness. 'When they brought in the T-inserter, they let Porson[--]' Then she stops, her expression that of a guppy being strangled. ".
  It quip-supplies the secretary.
-Understand "if" as  whether she enjoys her job.
 
  how she got this job is a questioning quip.
  It mentions employment.
@@ -2436,7 +2425,6 @@ whether public transport exists here is a questioning quip.
  The reply is "She smiles briefly. 'I'm sorry,' she says. 'There aren't any buses or subways here. The island is too small for that.'".
  It quip-supplies the attendant.
  It is background-information.
-Understand "if" as whether public transport exists here.
 
 Availability rule for whether we can keep the guidebook:
 	if the guidebook is marked invisible, it is off-limits;
@@ -2447,11 +2435,10 @@ Availability rule for whether we can keep the guidebook:
  The comment is "'Hey, does this guidebook belong to the hostel, or can I keep it?'".
  The reply is "'Sure, whatever,' she says. 'People take and leave stuff all the time. It's no big deal.'".
  It quip-supplies the attendant.
-Understand "if" as whether we can keep the guidebook.
 
  whether there seems an internet connection nearby is a questioning quip.
  The printed name is "whether there is an internet connection nearby". The true-name is "whether there seems an internet connection nearby".
- Understand "is" or "if" as whether there seems an internet connection nearby.
+ Understand "is" as whether there seems an internet connection nearby.
  It mentions internet.
  The comment is "'Hey, so, do you have internet here?'".
  The reply is "'Sorry,' she says. 'Our connection is suspended by the Bureau. Someone tried to use the hostel account for unauthor[ize]d contact with a universal translator.'
@@ -2462,7 +2449,7 @@ Did they indeed? I wonder who that could have been, hm?".
 
 whether there seem beds available is a questioning quip.
  The printed name is "whether there are beds available". The true-name is "whether there seem beds available".
- Understand "are" or "bed" or "space" or "room" or "if" as whether there seem beds available.  The comment is "'Are there free beds for the evening?'".
+ Understand "are" or "bed" or "space" or "room" as whether there seem beds available.  The comment is "'Are there free beds for the evening?'".
  The reply is "'Sure,' she says. 'You can go up and claim whichever free one you like. The hostel won't really fill up until this evening.'".
  It quip-supplies the attendant.
  It is background-information.
@@ -2518,7 +2505,6 @@ whether the gel resembles ours is a demonstration quip.
 We just smile and shrug pleasantly."
  It quip-supplies the attendant.
  It indirectly-follows how the All-Purpose makes blocks.
-Understand "if" as whether the gel resembles ours.
 
  why they do not use a locksmith is a questioning quip.
  It mentions locker.
@@ -2573,7 +2559,6 @@ whether the attendant enjoys her job is a questioning quip. The comment is "'Do 
  The reply is "She looks taken aback. 'It's a living,' she says. 'I mean, sort of. And the management doesn't really listen to what I tell them. And sometimes people are really loud. Or jerky. But my parents really really realllly wanted me to stay in school so I kind of stopped wanting to, if that makes sense. I don't know, maybe I'll go back later.'".
  It quip-supplies the attendant.
  It is background-information.
-Understand "if" as whether the attendant enjoys her job.
 
 Rule for quip-introducing sympathize on the topic of parents:
 	say "You apparently have a strong urge to sympath[ize] on the topic of parents. I don't.[line break]"
@@ -2662,7 +2647,7 @@ The greeting of backpacking girl is "'Greetings, fellow traveler!'"
 
 whether she seems really from canada is a questioning quip.
  The printed name is "whether she is really from Canada". The true-name is "whether she seems really from canada".
- Understand "if" or  "is" or "canadian" as whether she seems really from canada.  The comment is "'So,' we say, nodding at the pack. 'Are you really Canadian?'".
+ Understand "is" or "canadian" as whether she seems really from canada.  The comment is "'So,' we say, nodding at the pack. 'Are you really Canadian?'".
  It mentions heavy pack.
  The reply is "'Uh, no. I come from Ohio[fake-canada]. But don't tell anyone that. My mom thought this would be safer in case of terrorists. She's also worried about serial killers but there's not much I can do about that.'".
  It quip-supplies the backpacking girl.
@@ -2895,7 +2880,7 @@ Carry out discussing ask for privacy:
 
 whether she had trouble alongside customs is a questioning quip.
  The printed name is "whether she had trouble with customs". The true-name is "whether she had trouble alongside customs".
- Understand "with" or "if" as whether she had trouble alongside customs.  The comment is "'How was coming through Customs?' we ask. 'Any trouble there?'".
+ Understand "with" as whether she had trouble alongside customs.  The comment is "'How was coming through Customs?' we ask. 'Any trouble there?'".
  It mentions immigration.
  The reply is "'Not really. There were a few people in line, and they made me take all my stuff out of my backpack... and this one guy I saw them take away into a back room, and I don't think he ever came out again. But, uh, they were nice enough to me I guess. I was expecting worse.'".
  It quip-supplies the backpacking girl.
@@ -2960,7 +2945,7 @@ whether he believes in God is a questioning quip.
  The reply is "'Some of the time. The rest of the time I just wish I were.' He flattens his hands on the surface of the counter. They are veiny, with coarse thick nails. Some reflection about the end of life, or the perspective of old age, seems inevitable. But he says: 'You choose to believe or not. There's no such thing as absolute proof. So then the question is, do you want to believe in God? And, if so, what kind of God do you want to believe in? You go from there[casually queue curate-backstory].'".
  It quip-supplies the gift shop volunteer.
  It is background-information.
-Understand "if" or "man" or "volunteer" or "gift" or "shop" as whether he believes in God.
+Understand "man" or "volunteer" or "gift" or "shop" as whether he believes in God.
 
  what sort of God he believes in is a questioning quip.
  It mentions religion.
@@ -2974,7 +2959,7 @@ Rule for quip-introducing whether there seem points of architectural interest:
 
  whether there seem points of architectural interest is a weakly-phrased questioning quip.
  The printed name is "whether there are points of architectural interest". The true-name is "whether there seem points of architectural interest".
- Understand "if" or "are" as whether there seem points of architectural interest.
+ Understand "are" as whether there seem points of architectural interest.
  The comment is "'Are there, er, points of architectural interest about the Church?' we persist.".
  The reply is "'Not that I know of.'".
  It quip-supplies the gift shop volunteer.
@@ -3048,7 +3033,6 @@ whether he approves of government is a questioning quip. The comment is "'Do you
  The reply is "His eyes narrow sharply. 'That's not a question we get asked a lot around here,' he comments. 'It's a little like being asked whether you approve of the plumbing in your house, or the brake lines on your car. If it ever broke, you'd know, but the rest of the time you just don't give it much consideration. Underappreciated folks, our orthographers, but they work hard and they make things run smoothly, and barring the odd popular referendum we don't have to waste nearly as much time on arguing politics as folks in most countries.'".
  It quip-supplies the gift shop volunteer.
  It is background-information.
-Understand "if" as whether he approves of government.
 
 why he isn't at the celebration is a questioning quip. The comment is "'I'm surprised you're in here and not outside enjoying the festivities,' we comment.".
  It mentions celebration and gift shop volunteer.
@@ -3093,7 +3077,7 @@ Availability rule for what the restoration gel seems worth:
 
  whether the game seems rigged is a questioning quip.
  The printed name is "whether the game is rigged". The true-name is "whether the game seems rigged".
- Understand "is" or "if" as whether the game seems rigged.
+ Understand "is" as whether the game seems rigged.
  It mentions word-balance.
  The comment is "'I know this kind of game,' we say, in our most jaded voice. 'The scale is probably nailed in place so that it [i]can't[/i] tip.' One or two of the crowd standing nearby seem impressed by this line of argument. A small boy whispers to his sister to ask whether that could be true.".
  The reply is "'Nonsense,' says the barker angrily. To demonstrate the point, he pushes down on the left pan, and the scales tip and sway. He soon restores them to balance, though. [paragraph break]'And don't think that will count for you,' he adds. 'You have to put them out of balance yourself. No surrogates, substitutes, or alternatives allowed.'".
@@ -3105,7 +3089,6 @@ Availability rule for what the restoration gel seems worth:
  The reply is "'No one has won today,' he says, which is not an answer.".
  It quip-supplies the barker.
  It directly-follows barker-advertisement.
-Understand "if" as  whether anyone ever wins.
 
  compliment the blue suit is a performative quip.
  It mentions suit, fashion.
@@ -3232,10 +3215,9 @@ how the campaign will address problems of visualization is a questioning quip.
  It quip-supplies the activist.
  It is restrictive.
  It indirectly-follows how  campaign will address problems of visualization.
-Understand "if" as whether this liquid will be water.
 
  ask whether this liquid will also be flavorless is a performative quip.
-Understand "flavor" or "flavour" or "flavourless" or "if" as ask whether this liquid will also be flavorless.
+Understand "flavor" or "flavour" or "flavourless" as ask whether this liquid will also be flavorless.
  It mentions environment.
  The comment is "'[if immediately]Will it[otherwise]Will your proposed toxi waste liquid[end if] be flavorless, too?' you ask. I didn't come up with this one.".
  The reply is "'Huh?' [paragraph break]'I think,' you go on maliciously, 'that toxi waste should have a catchy flavor. Maybe spearmint.' [paragraph break]The furrow between her brows deepens as she tries to work out whether we are joking and, if so, what response would be appropriate. Finally she settles for, 'The ads are going to be on TV, so it's hard to show any flavors on television.'".
@@ -3367,7 +3349,7 @@ The greeting of the barman is "[one of]'Help you?' asks Parker the barman unenth
 
 whether he hath seen slango is a questioning quip.
  The printed name is "whether he has seen Slango". The true-name is "whether he hath seen slango".
- Understand "has" or "if" or "parker" or "barman" or "bartender" as whether he hath seen slango.  The comment is "'I wonder whether you've seen an associate of mine,' we say to Parker. 'Name of Slango.'".
+ Understand "has" or "parker" or "barman" or "bartender" as whether he hath seen slango.  The comment is "'I wonder whether you've seen an associate of mine,' we say to Parker. 'Name of Slango.'".
  It mentions Slango.
  The reply is "Parker looks over the bar at us. 'He comes in here from time to time,' he says. 'Very regular customer. Always has about three rum and cokes.' [paragraph break]This is a lie, and therefore a test. Slango doesn't drink alcohol himself and doesn't permit drunkenness in his crew.".
  It quip-supplies the barman.
@@ -3403,7 +3385,7 @@ Instead of asking the barman for the origin paste:
 
 whether we can hath the origin paste is a questioning quip.
  The printed name is "whether we can have the origin paste". The true-name is "whether we can hath origin paste".
- Understand "have" or "if" as whether we can hath origin paste.  The comment is "'That Origin Paste for sale?' ".
+ Understand "have" as whether we can hath origin paste.  The comment is "'That Origin Paste for sale?' ".
  It mentions origin paste.
  The reply is "'Well now,' he says, grinning, 'that would surely be illegal, would it not? Origin Paste is after all a controlled substance in this country, due to its unhappy association with fraudulent activities. On the other hand there is no law against someone [i]winning[/i] the Origin Paste in a completely legitimate game of chance or skill.'".
  It quip-supplies the barman.
@@ -3628,7 +3610,7 @@ Availability rule for whether he hath any other games going:
 
 whether he hath any other games going is a questioning quip.
  The printed name is "whether he has any other games going". The true-name is "whether he hath any other games going".
- Understand "if" or "has" or "parker/barman" as whether he hath any other games going.  The comment is "'So, is there anything else I can win? Any other games going?'".
+ Understand "has" or "parker/barman" as whether he hath any other games going.  The comment is "'So, is there anything else I can win? Any other games going?'".
  It mentions paste.
  The reply is "Parker laughs. 'Not until tomorrow, kid,' he says. 'We only run one game a day.'".
  It quip-supplies the barman.
@@ -3649,7 +3631,7 @@ Understand "parker/barman" as what he thinks about the Bureau.
  It is background-information.
 
 whether he hates customs officials is a performative quip. The comment is "'Do you hate Customs officials?' we ask.".
- Understand "parker/barman" or "if" as whether he hates customs officials.
+ Understand "parker/barman" as whether he hates customs officials.
  It mentions immigration, barman.
  The reply is "'Naw. Not running anything myself, am I?'".
  It quip-supplies the barman.
@@ -3663,7 +3645,7 @@ whether he believes in god 2 is a questioning quip. The comment is "'Where do yo
  The reply is "'Don't give it much thought,' he says. 'Please don't tell me you're here with a pamphlet . I won't read it.'".
  It quip-supplies the barman.
  It is background-information.
-Understand "if" or "parker/barman" as whether he believes in god 2.
+Understand "parker/barman" as whether he believes in god 2.
 
 Test tobarman with "test act1 / test chard / test car / test Slango-missed / go to outdoor / open backpack / look / wave p-remover at spill / get sill / go to counterfeit monkey".
 
@@ -3763,7 +3745,6 @@ Slango looks dyspeptic. 'Yeah, about that,' he says gruffly. You know better tha
  It quip-supplies Slango.
  It indirectly-follows who we seem.
  The proper scene is consulting-Slango.
-Understand "if" as whether we can leave now.
 
 After frowning when the current interlocutor is Slango and the current quip is whether we can leave now:
 	say "You're frowning, practically scowling. [run paragraph on]";
@@ -3895,7 +3876,7 @@ A plausibility rule for whether she hath seen slango when the player knows lena-
 
 whether she hath seen slango is a questioning quip.
  The printed name is "whether she has seen Slango". The true-name is "whether she hath seen slango".
- Understand "has" or "if" or "Lena" as whether she hath seen slango.  The comment is "[one of]'You wouldn't happen to have seen Slango about recently?' we ask.[or][if Lena does not know trust-me]'I'm still curious about Slango. Seen him?'[otherwise]'Now, you owe me one Slango,' you say. 'Where'd he get to?'[end if][stopping]".
+ Understand "has" or "Lena" as whether she hath seen slango.  The comment is "[one of]'You wouldn't happen to have seen Slango about recently?' we ask.[or][if Lena does not know trust-me]'I'm still curious about Slango. Seen him?'[otherwise]'Now, you owe me one Slango,' you say. 'Where'd he get to?'[end if][stopping]".
  It mentions Slango.
  The reply is "'Slango and I were catching up. Bless that man, he's hung like a yak,' she says. 'But he got bad news and had to hurry back to the yacht. Said something about not being able to keep an appointment. I take it you're the appointment? I can try reaching him for you, if you want.'".
  It quip-supplies Lena.
@@ -4226,7 +4207,6 @@ He comes back in a minute.
 
 'There,' he says. 'Should be abstract-enabled now.'"
  It quip-supplies Professor Brown.
- Understand "if" as whether he can fix the letter-remover.
 
 what he thinks of the letter-remover is a demonstration quip.
  It mentions the letter-remover.
@@ -4574,7 +4554,6 @@ Instead of saying yes when Waterstone is marked-visible and make up some excuse 
  The comment is "'Did you run into those activists outside?'".
  The reply is "'Sadly, it is our misfortune constantly to encounter people with no concept of what language manipulation can and cannot do,' Waterstone says. He really seems to be in a bad mood today, even for him: maybe a fight with the wife, or a nasty letter from the dean.".
  It quip-supplies Professor Waterstone.
-Understand "if" as whether he met the activists.
 
 what he kens about me is an unlisted questioning quip.
  The printed name is "what he knows about me". The true-name is "what he kens about me".
@@ -5630,7 +5609,6 @@ whether the protesters feel the same way is a questioning quip. The comment is "
  The reply is "Atlantida shrugs off our question. 'A vocal minority. Most people are content to keep what they have. Imagine the chaos if everyone had free access to the Bureau's complete range of letter tools, and if there were no laws about how to use them[casually queue more-about-democracy].'".
  It quip-supplies Atlantida-woman.
  It directly-follows thing-about-democracy.
-Understand "if" as whether the protesters feel the same way.
 
 Carry out Atlantida-woman discussing gel-shot:
 	now the player is gelled.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -928,11 +928,14 @@ Definition: a thing is farmer-carried if the farmer carries it.
 
 Carry out requesting it from:
 	let N be a random quip which mentions the noun;
-	try discussing N instead.
+	try discussing N with the second noun instead.
 
 Availability rule for what seems for sale:
 	if the farmer carries something, make no decision;
 	otherwise it is off-limits.
+
+Before requesting something from the farmer when the player does not recollect what seems for sale:
+	try buying the noun from the farmer instead.
 
 Before buying something from the farmer when the player does not recollect what seems for sale:
 	if the farmer is not the current interlocutor:
@@ -943,7 +946,7 @@ Before buying something from the farmer when the player does not recollect what 
  what seems for sale is a questioning quip.
  The printed name is "what is for sale". The true-name is "what seems for sale".
  Understand "is" or "market" as what seems for sale.
- It mentions farmer.
+ It mentions farmer, farmer's stall.
  The comment is "'What is for sale?' we ask.".
  The reply is "'[one of]We have available [a list of things *in the farmer][or]I got [a list of things *in the farmer][or]All that's left this time of day is [a list of things *in the farmer][at random],' the farmer replies.".
  It quip-supplies the farmer.
@@ -956,7 +959,7 @@ Availability rule for what seems for sale-2:
  what seems for sale-2 is a questioning quip.
  The printed name is "what is for sale". The true-name is "what seems for sale-2".
  Understand "is" or "sale" as what seems for sale-2.
- It mentions farmer.
+ It mentions farmer, farmer's stall.
  The comment is "'What is for sale?' we ask.".
  The reply is "'Oh, nothing,' says the farmer. 'But as my mother-in-law is in town, I thought I would make the most of the market day.' He smiles at us.".
  It quip-supplies the farmer.
@@ -1588,7 +1591,7 @@ Does the player mean asking the bartender to try attacking something with the ho
 Does the player mean asking the bartender to try attacking something with something that is not the homonym paddle:
 	it is very unlikely.
 
-After reading a command:
+After reading a command when location is Fleur d'Or Drinks Club:
 	if the player's command includes "tell bartender to" or the player's command includes "ask bartender to":
 		replace the matched text with "bartender,".
 
@@ -2267,6 +2270,15 @@ Does the player mean buying the ticket-taker from someone:
 Does the player mean buying the hidden-ticket from the ticket-taker:
 	it is very likely.
 
+Does the player mean subject-asking the hidden-ticket:
+	it is very likely.
+
+Sanity-check object-asking the ticket when the current interlocutor is the ticket-taker:
+	try discussing buy movie-ticket instead.
+
+Sanity-check object-asking the hidden-ticket when the current interlocutor is the ticket-taker:
+	try discussing buy movie-ticket instead.
+
 buy movie-ticket is a purchasing quip.
 The printed name is "buy a movie ticket".
 Understand "buy the/a ticket" or "movie" or "ticket" or "buy a/the movie ticket" as buy movie-ticket.
@@ -2564,7 +2576,7 @@ whether the attendant enjoys her job is a questioning quip. The comment is "'Do 
 Understand "if" as whether the attendant enjoys her job.
 
 Rule for quip-introducing sympathize on the topic of parents:
-	say "You apparently have a strong urge to sympath[ize] on the topic of parents. I don't."
+	say "You apparently have a strong urge to sympath[ize] on the topic of parents. I don't.[line break]"
 
  sympathize on the topic of parents is a performative quip.
 	Understand "sympathise" as sympathize on the topic of parents.
@@ -2619,7 +2631,7 @@ Rule for beat-producing when the current interlocutor is the backpacking girl:
 			say run paragraph on;
 			try the backpacking girl trying examining the player;
 		otherwise:
-			say "[one of]She tosses restlessly[or]She turns over[or]She bangs her head against the space where a pillow ought to be[or]She scrubs at her eyes with one hand[at random].[run paragraph on]".
+			say "[one of]She tosses restlessly[or]She turns over[or]She bangs her head against the space where a pillow ought to be[or]She scrubs at her eyes with one hand[at random]. ".
 
 
 Report the backpacking girl trying dropping the heavy pack:
@@ -2869,6 +2881,10 @@ A first conversation-reply rule when the current interlocutor is the backpacking
 Instead of waiting when the current interlocutor is the backpacking girl:
 	say "[beat][paragraph break]".
 
+A last after reading a command rule when current interlocutor is the backpacking girl and ask for privacy is available:
+	if the player's command matches "ask for privacy":
+		change the text of the player's command to "privacy";
+
  ask for privacy is a repeatable performative quip. The comment is "[one of]'Would you mind giving me a minute?' we say. 'Sorry, I could just use a little privacy.'[or]'I'd really like to be alone for a couple of minutes now,' we say.[or]'This will just take a moment, but you would you mind giving me the room to myself?' we say.[at random]".
  It mentions yourself.
  The reply is "[one of]She waves a hand generously. 'Don't worry about it, do whatever you've got to do, I don't care,' she says. 'I'm so tired I couldn't move a muscle, but I've seen everything. I have three brothers and two sisters and I'm in women's rugby so I'm pretty hard to shock.'[or]She just grunts and waves to indicate we may strip naked at our leisure.[or]'Dude,' she says, exasperated. 'If you wanted a private room you should've not stayed at a freaking hostel.'[or]She moans.[stopping]".
@@ -2897,9 +2913,9 @@ The generic adversative of the gift shop volunteer is "[one of]alas[or]sadly[at 
 The secondary apology of the gift shop volunteer is "[one of]sorry[or]I'm afraid[at random]".
 The generic confrontational of the gift shop volunteer is "miss".
 
-Instead of asking the gift shop volunteer about something:
+Instead of object-asking when the current interlocutor is the gift shop volunteer:
 	let N be "[one of][generic adversative of the gift shop volunteer][or][secondary apology of the gift shop volunteer][at random]" in sentence case;
-	say "[We] frame up a vague question about [the topic understood].
+	say "[We] frame up a vague question about [the noun].
 
 [beat] '[N], don't think I can help you there.'[paragraph break][conditional paragraph break]"
 ["[We] frame up a vague question about [second noun].]
@@ -3481,8 +3497,8 @@ Understand "choose [something]" as showing it to when play the game is the curre
 Rule for supplying a missing second noun while showing something to:
 	if the current interlocutor is a person:
 		now the second noun is the current interlocutor;
-	otherwise if the number of marked-visible other people is 1:
-		implicitly greet a random marked-visible person who is not the player;
+	otherwise if how-many-people-here is 1:
+		implicitly greet entry 1 of people-present;
 		now the second noun is the current interlocutor;
 	otherwise:
 		say "You must show [the noun] to someone specific."
@@ -4389,7 +4405,7 @@ It is background-information.
 [Originally the novel was in Fukhian, which I picked off a webpage on constructed languages because I liked the look of the script. But later, reading Arika Okrent's In the Land of Invented Languages as research, I ran across Láadan, which — with its highly elaborated vocabulary of body parts, and the sentence modifiers that mean things like 'I say the following in a loving fashion' — seemed a more likely language for constructed romance novels.]
 
 whether Professor Higgate would translate part of the novel is a questioning quip.
- Understand "she" or "if" as whether Professor Higgate would translate part of the novel.
+ Understand "she" as whether Professor Higgate would translate part of the novel.
  It mentions constructed language, heart to heart.
  The comment is "'Would you translate part of it for me?' we ask.".
  The reply is "The blush deepens. 'Well, some of the ideas are hard to express in single words of English. This suffix, for instance, has a pejorative meaning, so when it is attached to, ah, the word for experiencing a sexual act, that may suggest that the act was unsatisfactory.'".
@@ -4397,7 +4413,6 @@ whether Professor Higgate would translate part of the novel is a questioning qui
  It directly-follows what the romance novel might be.
 
  whether she encountered activists is a questioning quip.
- Understand "if" as whether she encountered activists.
  It mentions activist, environment.
  The comment is "'Did you by any chance encounter some activists on the way into the building?' we ask. 'I had a hard time getting in here because they wanted to talk to me about toxi waste.'".
  The reply is "'[i]Yes[/i],' she says. 'Now those kids! If we needed proof of the social value of what we're doing here, they're a perfect example. I admire their enthusiasm, don't get me wrong, but the whole idea of single-term manipulation is hopelessly wrong-headed, and if they spent a semester or two in a Language Studies class, they'd understand why.'".
@@ -4409,7 +4424,7 @@ An availability rule for whether she might let us into the language studies semi
 		it is off-limits.
 
 whether she might let us into the language studies seminar room is a questioning quip. The comment is "'Could you possibly let me into the Language Studies Seminar Room?' we ask. 'There's something I'd like to do in there.'".
- Understand "higgate" or "her" or "professor" or "if" as whether she might let us into the language studies seminar room.
+ Understand "higgate" or "her" or "professor" as whether she might let us into the language studies seminar room.
  It mentions seminar door, key.
  The reply is "'Er... Do you have some student ID or something? You see, and this is a little embarrassing, I'm afraid I'm not quite placing you at the moment, and I'm not supposed to allow students into that room unless they have some affiliation with the department.'
 
@@ -4596,8 +4611,9 @@ Please-get-out is an NPC-directed quip.
 Report someone discussing please-get-out:
 	say "[reply of please-get-out][paragraph break]";
 	reset the interlocutor;
-	try going south;
-	shut the office instead.
+	move the player to Language Studies Department Office, without printing a room description;
+	shut the office;
+	try looking instead.
 
 [At the time when Waterstone gets annoyed:
 	if the location is not Waterstone's Office:
@@ -5037,7 +5053,7 @@ Section 9 - Mother
 [ Mother has only this one brief scene, but she's an important influence in Alex's life: a source of cosmopolitan and slightly subversive ideas, more in touch with the world outside than Alex's father, and source of the unquestioned privilege of his upbringing. ]
 
 My mother is a woman.
-Understand "mom" or "ma" or "mum" or "mommy" as mother.
+Understand "mom" or "ma" or "mum" or "mommy" or "rosehip" or "mrs rosehip" as mother.
 The initial appearance is "My mother is here, looking around as though she would like to comment on my housekeeping."
 The description of my mother is "She is a tall woman with short brown hair expertly cut, and a tailored suit."
 The introduction is "She has in addition a certain air which is very rare on this island: the air of seeming not to care whether anyone is watching her, or whether she is exhibiting the proper respect for authority."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
@@ -87,10 +87,10 @@ Rule for supplying a missing second noun while buying something from:
 	if the current interlocutor is a person:
 		now the second noun is the current interlocutor;
 	otherwise if somebody (called target) encloses the noun:
-		implicitly greet the target;
+		try saying hello to the target;
 		now the second noun is the current interlocutor;
 	otherwise if how-many-people-here is 1:
-		implicitly greet entry 1 of people-present;
+		try saying hello to entry 1 of people-present;
 		now the second noun is the current interlocutor;
 	otherwise:
 		say "From whom should [we] buy [the noun]?".

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
@@ -107,6 +107,13 @@ After reading a command:
 
 Understand "hey" or "hiya" or "yo" as hailing.
 
+After reading a command when the current interlocutor is not nothing and player's command includes "ask/tell/a/t" and the player's command includes "about" and the player's command does not include "ask/tell/a/t about" (this is the new strip interlocutor from input rule):
+	unless the location is Counterfeit Monkey and the player's command includes "men":
+		if the player's command includes "[someone talk-eligible]":
+			cut the matched text.
+
+The new strip interlocutor from input rule is listed instead of the strip interlocutor from input rule in the After reading a command rules.
+
 The Hostel-as-subject is a subject. The printed name is "hostel". Understand "hostel" as the hostel-as-subject.
 The Fleur d'or-as-subject is a subject. The printed name is "Fleur d'or hotel". Understand "hotel" or "fleur" or "d'or" as the fleur d'or-as-subject.
 The Cinema-as-subject is a subject. The printed name is "cinema". Understand "cinema" as the cinema-as-subject.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -2086,7 +2086,7 @@ There is no immediate reaction, but after a few minutes a cramping pain begins t
 
 Test pill with "tutorial off / wave s-remover at spill / take pill / take all / get pill / get a pill / take the pill / take pill" in the outdoor cafe.
 
-After reading a command:
+After reading a command when the player carries the pill or the player carries the pills:
 	if the player's command matches "take pill":
 		if the player carries the pill:
 			replace the player's command with "eat pill";

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -487,8 +487,6 @@ Understand "list mentions" as listing-subjects. Listing-subjects is an action ou
 Understand "list available subjects" as listing-available-subjects. Listing-available-subjects is an action out of world. Carry out listing-available-subjects:
 		say "[available-subjects in brace notation]".
 
-
-
 Understand "list quips" as listing-quips. Listing-quips is an action out of world.
 Carry out listing-quips:
 	let L be the list of quips;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -484,6 +484,11 @@ Carry out listing all sizes:
 Understand "list mentions" as listing-subjects. Listing-subjects is an action out of world. Carry out listing-subjects:
 		show relation mentioning relation.
 
+Understand "list available subjects" as listing-available-subjects. Listing-available-subjects is an action out of world. Carry out listing-available-subjects:
+		say "[available-subjects in brace notation]".
+
+
+
 Understand "list quips" as listing-quips. Listing-quips is an action out of world.
 Carry out listing-quips:
 	let L be the list of quips;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -41,7 +41,7 @@ The stripping body parts rule is not listed in any rulebook. [We don't want the 
 The offer new prompt rule is not listed in any rulebook.
 
 Before reading a command when tutorial mode is true (this is the alternate new prompt rule):
-	if sp reparse flag is false and identification is not happening:
+	if sp reparse flag is false and tc reparse flag is false and identification is not happening:
 		follow the instructional rules.
 
 The new stripping adverbs rule is listed instead of the stripping adverbs rule in the Smarter Parser rulebook.

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Actions.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Actions.i7x
@@ -39,22 +39,22 @@ Before attacking someone who is not the current interlocutor  (this is the impli
 
 	
 Instead of kissing someone (this is the standard kiss redirection rule):
-	if a seductive quip (called target quip) is available
+	[if a seductive quip (called target quip) is available
 	begin;
 		if the number of available seductive quips is 1, try discussing the target quip;
 		otherwise recommend available seductive quips; 
-	otherwise; 
-		carry out the refusing to kiss activity with the noun;
-	end if.
+	otherwise;]
+	carry out the refusing to kiss activity with the noun.
+	[end if.]
 
 Instead of attacking someone (this is the standard attack redirection rule):
-	if an offensive quip (called target quip) is available
+	[if an offensive quip (called target quip) is available
 	begin;
 		if the number of available offensive quips is 1, try discussing the target quip;
 		otherwise recommend available offensive quips; 
-	otherwise; 
-		carry out the refusing to attack activity with the noun;
-	end if.
+	otherwise;]
+	carry out the refusing to attack activity with the noun.
+	[end if.]
 
 Carry out buying something from someone (this is the standard purchasing rule):
 	let N be the list of available purchasing quips which mention the noun;

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Threaded Conversation.i7x
@@ -48,7 +48,7 @@ A subject is a kind of object. The specification of a subject is "Something that
 
 Part Two - Defining Quips
 
-A quip is a kind of thing. The specification of a quip is "A comment for the player to make. NPCs may respond in different ways."
+A quip is a kind of scenery thing. The specification of a quip is "A comment for the player to make. NPCs may respond in different ways."
 	A quip has some text called the comment. [The PC's speech.]
 	A quip has some text called the reply. [The NPC's response.]
 	A quip has some text called the nag.
@@ -83,8 +83,7 @@ The grandparent quip is a quip that varies.
 [	This could have been done with a list, but in practice it is more efficient, and not significantly less useful, to track only the most recent three.	]
 
 
-generic-quip is a quip. Availability rule for generic-quip: it is off-limits. [A starter quip, so that TC will compile even before any conversation has been defined.]
-
+generic-quip is a npc-directed quip. Availability rule for generic-quip: it is off-limits. [A starter quip, so that TC will compile even before any conversation has been defined.]
 
 Definition: a quip is viable if it is in the quip-repository.
 
@@ -109,9 +108,9 @@ Part One - Quip Relations to Things
 
 Mentioning relates various quips to various things. The verb to mention implies the mentioning relation.
 
-Understand "[something related by mentioning]" as a quip.
+[Understand "[something related by mentioning]" as a quip.
 [	This apparently humble line means that we can define a quip with the line "It mentions the queen." and then the player can use any vocabulary that pertains to the queen to raise this quip;	]
-[	as in ASK ABOUT WOMAN, ASK ABOUT MONARCH, and so on.	]
+[	as in ASK ABOUT WOMAN, ASK ABOUT MONARCH, and so on.	]]
 
 
 Part Two - Quip Relations to Speakers
@@ -139,7 +138,7 @@ The verb to indirectly-follow (it indirectly-follows, they indirectly-follow, it
 When play begins (this is the indirect-following initializing rule):
 	repeat with item running through quips:
 		now every quip which is directly-followed by the item is indirectly-followed by the item.
-	
+
 To decide whether immediately:
 [This convenient check allows us to vary quip text depending on whether we're following up on earlier conversation right away or belatedly.]
 	decide on whether or not the current quip indirectly-follows the previous quip.
@@ -171,7 +170,7 @@ Before printing the name of a fact (called target) (this is the player learns fa
 
 Rule for printing the name of a fact (this is the silence actual output of facts rule):
 	do nothing instead.
-	
+
 To say forget (target - a fact):
 	repeat with listener running through people-present[who can see the person asked]:
 		now the listener does not know the target.
@@ -223,8 +222,8 @@ Part Two - Cache-building
 [	To make the cache build again, delete the original cache from your source and re-compile the game.	]
 [		]
 [	To make this feature work, add the line	]
-[		
-	      Use hard cache.	
+[
+	      Use hard cache.
 		]
 [	to the main source of the game.	]
 
@@ -245,8 +244,8 @@ Definition: a quip is cachable
 	or it is dead-ended
 	or it is shallowly-buried.
 
-	
-	
+
+
 
 VOLUME TWO - RECOMMENDING QUIPS TO THE PLAYER
 
@@ -271,7 +270,7 @@ A plausibility rule for a quip (called target) (this is the avoid topic-change w
 
 The last plausibility rule (this is the generic plausibility rule):
 	it is plausible.
-	
+
 Chapter 1 - Quippish relevance
 
 A quip can be marked-relevant or unmarked-relevant. [This has a crunchy name because it's a completely internal way of stashing information.]
@@ -289,7 +288,7 @@ Definition: a quip (called target) is quippishly-relevant:
 	otherwise:
 		now the target is unmarked-relevant;
 		no.
-		
+
 Chapter 2 -
 
 Definition: a quip is recent
@@ -382,7 +381,7 @@ An availability rule for a mid-thread quip (called the target) (this is the rest
 
 The last availability rule (this is the generic availability rule):
 	it is available.
-	
+
 
 Book 3- Peripheral Quips
 
@@ -420,10 +419,10 @@ Listing plausible quips is an activity.
 A quip can be listed-plausible or unlisted-plausible.
 
 Before listing plausible quips (this is the initialize quip plausibility before hinting rule):
-	now every quip is unlisted-plausible.
+	now every quip in quip-repository is unlisted-plausible.
 
 Before asking which do you mean (this is the initialize quip plausibility before disambiguating rule):
-	now every quip is unlisted-plausible.
+	now every quip in quip-repository is unlisted-plausible.
 
 After printing the name of a quip (called target) while asking which do you mean (this is the mark disambiguated quips plausible rule):
 	now the target is listed-plausible.
@@ -494,7 +493,8 @@ Section 3 - Offer Hint Quips Rule
 
 This is the offer hint quips rule:
 	if how-many-people-here is positive:
-		carry out the listing plausible quips activity. [Hint about quips if there's something on the table that's particularly unusual.]
+		if tc reparse flag is false and sp reparse flag is false: [Don't want to also display hints before conversation, if we just implicitly greeted someone]
+			carry out the listing plausible quips activity. [Hint about quips if there's something on the table that's particularly unusual.]
 
 The offer hint quips rule is listed after the adjust light rule in the turn sequence rules.
 
@@ -504,9 +504,13 @@ The offer hint quips rule is listed after the adjust light rule in the turn sequ
 This is the relabel available quips rule:
 	if how-many-people-here is positive:
 		now every quip is flagged-unready;
+		now available-subjects is {};
 		repeat with item running through things in the quip-repository:
 			if item is available:
-				now item is flagged-ready. [* This means that we can also remove things from the quip-repository in order to skip considering them; if for instance we only want to consider quips relevant to the current scene, or the current character.]
+				now item is flagged-ready;
+				repeat with new subject running through things mentioned by item:
+					add new subject to available-subjects, if absent.
+				[* This means that we can also remove things from the quip-repository in order to skip considering them; if for instance we only want to consider quips relevant to the current scene, or the current character.]
 
 A quip can be flagged-ready or flagged-unready.
 
@@ -522,8 +526,8 @@ Book 5 - Disambiguation
 Section 1 - Stripping Add-ons from Player's Command
 
 After reading a command (this is the flatten ifs rule):
-	if the player's command includes "ask if":
-		replace the matched text with "ask whether".
+	while the player's command includes "if": ["ask if":]
+		replace the matched text with "whether". ["ask whether".]
 
 After reading a command:
 	if the player's command matches "say" or the player's command matches "ask": [These are for cases where the player has provided a simple command with no specific direct object]
@@ -537,8 +541,6 @@ Section 2 - Identifying Matched Quips
 
 [Bland as these may seem, they're the result of a lot of testing about what produces the most sensible defaults. Modify with caution.]
 
-Definition: a direction is parse-matched if it fits the parse list.
-Definition: a room is parse-matched if it fits the parse list.
 Definition: a thing is parse-matched if it fits the parse list.
 
 To decide whether (N - an object) fits the parse list:
@@ -558,60 +560,14 @@ Include (-
 #endif;
 -)
 
-To decide whether everything matched is a quip:
-	(- CheckParseList() -)
+Disambiguating quips is initially false.
 
-Include (-
-#ifndef CheckParseList;
-[ CheckParseList obj i k marker;
-	marker = 0;
-	for (i=1 : i<=number_of_classes : i++) {
-	while (((match_classes-->marker) ~= i) && ((match_classes-->marker) ~= -i)) marker++;
-	k = match_list-->marker;
-	if (~~(k ofclass (+ quip +) ) ) rfalse;
-	}
-	rtrue;
-];
-#endif;
-
-#ifndef MatchList;
-[ Matchlist obj i k  j stored_obj stored_wn marker;
-	marker = 0;
-	for (i=1 : i<=number_of_classes : i++) {
-		while (((match_classes-->marker) ~= i) && ((match_classes-->marker) ~= -i)) marker++;
-		k = match_list-->marker;
-		j = k.parse_name();
-		if (j > stored_wn)
-		{
-			stored_wn = j;
-			stored_obj = k;
-		}
-		if (i == number_of_classes)
-		{	print "";
-		}
-	}
-	if (stored_wn > 0)
-	{	return stored_obj;
-	}
-];
-#endif;
-
--)
-
-Disambiguating quips is a truth state that varies. Disambiguating quips is false.
-
-Rule for asking which do you mean when everything matched is a quip:
+Rule for asking which do you mean when everything parse-matched is a quip:
+	if the current interlocutor is not a person,
+		say "[text of cannot talk without an interlocutor rule response (A)][line break]" instead; ['You're not talking to anyone right now']
 	now disambiguating quips is true;
 	carry out the listing matched quips activity.
 
-[After reading a command when disambiguating quips is true:
-	now disambiguating quips is false;
-	let best choice be the pre-matched quip;
-	reject the player's command;
-	rule succeeds.]
-
-To decide what object is the pre-matched quip:
-	(- Matchlist() -)
 
 Section 3 - Listing Matched Quips to the Player
 
@@ -623,7 +579,12 @@ Rule for listing matched quips (this is the standard quip disambiguation rule):
 	repeat with item running through L:
 		choose a blank row in the Table of Scored Listing;
 		now output entry is the item; [* There are easier ways to do this, but I've handcoded it for speed reasons.]
-	say "What would you like to discuss: [the prepared list delimited in disjunctive style]?"
+	say "What would you like to discuss: [the prepared list delimited in disjunctive style]?"[;
+	let N be 1;
+	repeat through Table of Scored Listing:
+		now disambiguation id of output entry is N;
+		increment N.]
+[The disambiguation choices get numbered back-to-front sometimes, but I'll leave this commented out until I know more about why and what the correct way to fix it is.]
 
 
 Section 4 - Preferring Quips Among Multiple Matches
@@ -664,10 +625,18 @@ Understand "herself" as a woman when the item described is the current interlocu
 
 Definition: a person is talk-eligible if it is the current interlocutor.
 
-The quip-repository is a privately-named transparent closed unopenable container.
+The quip-repository is a privately-named proper-named transparent closed unopenable scenery container. The printed name of the quip-repository is "[player]".
 
 When play begins (this is the move all quips to the quip-repository rule):
 	now every quip that is not npc-directed is in the quip-repository.
+
+Rule for writing a paragraph about the quip-repository:
+	do nothing instead.
+
+Rule for disclosing contents of the quip-repository:
+	do nothing instead.
+
+A ranking rule for the quip-repository: decrease description-rank of the quip-repository by 100.
 
 Book 2 - The Discussing Action
 
@@ -675,81 +644,161 @@ Book 2 - The Discussing Action
 
 This will need to manage the player input to allow different conversation actions; it will need to determine which quips are currently plausible (either to be put on the menu or to be recommended).]
 
-Section 1 - Understanding and Basic Definitions
 
-Understand the command "ask" as something new.
-Understand the command "tell" as something new.
-Understand the command "say" as something new.
-Understand the command "answer" as something new.
+Chapter 1 - Understanding and basic definitions
+
+Understand the commands "ask", "tell", "say",  "discuss", "answer", "a", "t" as something new.
+
+[To say regarding it: now the prior named object is nothing. [A useful shorthand.]] [Useful for what?]
+
+[This is slightly redundant as listed-plausible is a subset of flagged-ready. But it might speed up the identification of listed-plausible quips.]
+Definition: a quip is typable if it is listed-plausible or it is flagged-ready.
+
+After deciding the scope of the player while discussing, discussing something with (this is the quip scope handling rule):
+	place the quip-repository in scope.
+	[This is a bit of a hack, but the out-of-play container turns out to be a very convenient way to control the scope-limiting of quips.]
+
+Available-subjects is a list of objects that varies.
+
+After deciding the scope of the player while subject-asking (this is the ask about scope handling rule):
+	repeat with item running through available-subjects:
+		place item in scope.
+
+[Understand "say bye/goodbye/cheerio/farewell" as leavetaking. [The system needs to recognize that this is not an attempt at conversation.]]
+
+Section 1a - discussing it with
 
 Discussing it with is an action applying to two visible things.
+
+Understand
+	"discuss [a typable quip] with [someone]" or
+	"say [a typable quip] to [someone]" as discussing it with
+	when the current interlocutor is a person.
+
+Understand
+	"tell [someone] [a typable informative quip]" or
+	"ask [someone] [a typable questioning quip]" or
+	"tell [someone] that/about [a typable informative quip]" or
+	"ask [someone] that/about [a typable questioning quip]" as discussing it with (with nouns reversed)
+	when the current interlocutor is a person.
+
+Does the player mean discussing a listed-plausible quip:
+	it is very likely.
+
+Definition: a thing is relevant-subject if it is listed in available-subjects.
+
+Understand "ask about/-- [a relevant-subject thing]" or "tell about/-- [a relevant-subject thing]" as subject-asking. Subject-asking is an action applying to one visible thing.
+
+Carry out subject-asking:
+	if there is a listed-plausible quip (called target quip) that mentions the noun:
+		try discussing target quip;
+	otherwise:
+		try discussing a random flagged-ready quip that mentions the noun.
+
+Understand "ask about/for [something]" as object-asking. Object-asking is an action applying to one visible thing.
+
+[This is meant as a catch-all for asking about unimplemented present things]
+
+Carry out object-asking:
+	if the current interlocutor is nothing and how-many-people-here is 1:
+		let new interlocutor be entry 1 of people-present;
+		implicitly greet new interlocutor;
+		if new interlocutor is the current interlocutor:
+			follow the relabel available quips rule;
+			if there is a flagged-ready quip that mentions the noun:
+				try subject-asking the noun instead;
+	if the current interlocutor is nothing:
+		say "[We] [aren't] talking to anyone." instead;
+	if the current interlocutor carries the noun:
+		try requesting the noun from the current interlocutor;
+	otherwise:
+		unless the noun is a distant backdrop or the noun is a person:
+			try showing the noun to the current interlocutor;
+		otherwise:
+			carry out the refusing comment by activity with the current interlocutor.
+
+After reading a command when the current interlocutor is not nothing and player's command includes "ask/tell/a/t" and the player's command includes "about" and the player's command does not include "ask/tell/a/t about" (this is the strip interlocutor from input rule):
+	if the player's command includes "[someone talk-eligible]":
+		cut the matched text.
+
+Rule for supplying a missing noun when discussing something with and the player's command includes "[a quip]" (this is the interlocutor is assumed rule):
+	try discussing the second noun instead.
+
+Check discussing something with a talk-ineligible person (this is the implicitly greet a named potential conversant rule):
+	implicitly greet the second noun;
+	if the second noun is the current interlocutor:
+		follow the relabel available quips rule; [We need to ready the set of quips supplying this new interlocutor.]
+	otherwise:
+		say "[We] [aren't] talking to [the second noun]." (A) instead.
 
 Carry out discussing it with:
 	try discussing the noun.
 
-Discussing is an action applying to one visible thing. Understand "talk [any listed-plausible quip]" as discussing.
+Section 1b - discussing
 
-[[We do this in order to strip out *dozens* of variant grammar lines that would otherwise have to be accounted for, and to make sure that DISCUSS GEORGE is handled right, even if GEORGE is the interlocutor -- some odd corner cases can arise if we try to handle everything just via grammar lines, where Inform gets confused between whether we're asking someone something or whether we're asking about that person.]
+Discussing is an action applying to one visible thing.
 
-After reading a command when the player's command includes "ask/talk/say/tell/discuss/answer" (this is the remove interlocutor's name rule):
-	if disambiguating quips is true:
-		make no decision; [for some reason, when used on disambiguating command lines, this rule a) takes forever and then b) doesn't work right anyway]
-	if the player's command includes "with/to [a talk-eligible person]":
-		cut the matched text;
-	if the player's command includes "[a talk-eligible person] that/about":
-		cut the matched text;
-	if the player's command includes "[a talk-eligible person]":
-		if the player's command matches "ask/tell/talk/say/tell/discuss/answer [a talk-eligible person]":
-			do nothing;
-		otherwise:
-			cut the matched text;
-	if the player's command includes "ask/tell/talk about":
-		replace the matched text with "say";]
+Understand
+	"talk about/-- [a typable quip]" and
+	"say [a typable quip]" and
+	"discuss [a typable quip]" as discussing.
 
-Understand "talk [any listed-plausible quip]" or "discuss [any listed-plausible quip]" or "change the subject to [any listed-plausible quip]" or "change subject to [any listed-plausible quip]" as discussing.
+Understand
+	"change the/-- subject to [a typable quip]" and
+	"tell about [a typable informative quip]" and
+	"ask about [a typable questioning quip]" and
+	"tell [a typable informative quip]" and
+	"ask [a typable questioning quip]" as discussing.
 
-Understand "t [any listed-plausible quip]" or  "tell [any listed-plausible quip]" or "say [any  listed-plausible quip]" or "ask [any listed-plausible quip]" or  "tell about [any listed-plausible quip]" or "talk about [any  listed-plausible quip]" or "ask about [any listed-plausible quip]" or "a [any  listed-plausible quip]" as discussing.
+Understand the command "a" as "ask".
+Understand the command "t" as "tell".
 
-Understand "[any listed-plausible performative quip]" as discussing.
+Understand "[a typable quip]" as discussing. [This originally read "a typable performative quip"; let's see if this greater permissiveness breaks anything...]
 
 
-Understand "tell [a talk-eligible person] that/about [any listed-plausible quip]" or "ask [a talk-eligible person] that/about [any listed-plausible quip]" or "tell [a talk-eligible person] [any listed-plausible quip]" or "ask [a talk-eligible person] [any listed-plausible quip]" as discussing it with (with nouns reversed). Understand "discuss [any listed-plausible quip] with [a talk-eligible person]" or "say [any listed-plausible quip] to [a talk-eligible person]" as discussing it with.
+Chapter 2 - Setting discussing variables
 
-Understand "talk [any flagged-ready quip]" or "discuss [any flagged-ready quip]" or "change subject to [any flagged-ready quip]" as discussing.
-
-Understand "t [any flagged-ready quip]" or "say [any flagged-ready quip]" or "ask [any flagged-ready quip]" or  "tell about [any flagged-ready quip]" or "talk about [any flagged-ready quip]" or "ask about [any flagged-ready quip]" or "a [any flagged-ready quip]" as discussing.
-
-Understand "tell [a talk-eligible person] that/about [any flagged-ready quip]" or "ask [a talk-eligible person] that/about [any flagged-ready quip]" or "tell [a talk-eligible person] [any flagged-ready quip]" or "ask [a talk-eligible person] [any flagged-ready quip]" as discussing it with (with nouns reversed). Understand "discuss [any flagged-ready quip] with [a talk-eligible person]" or "say [any flagged-ready quip] to [a talk-eligible person]" as discussing it with.
-
-Understand "[any flagged-ready performative quip]" as discussing.
-
-Understand "talk [any flagged-ready quip]" or "discuss [any flagged-ready quip]" or "change subject to [any flagged-ready quip]" as discussing.
-
-Understand "t [any flagged-ready quip]" or "say [any flagged-ready quip]" or "ask [any flagged-ready quip]" or "a [any flagged-ready quip]" as discussing.
-
-Understand "[any flagged-ready performative quip]" as discussing.
-
-[Does the player mean discussing a listed-plausible quip:
-	it is very likely.]
-
-Section 2 - Setting Discussing Variables
-
-[The discussing action has a person called listener (matched as "with"). ]
+Break after reply is a truth state that varies. [If a character has multiple replies in a single turn, we don't want the final paragraph breaks to stack up.]
 
 Setting action variables for an actor discussing:
-	[if the person asked is the player:
-		now the listener is the current interlocutor;
-	otherwise now the listener is the player; ]
-	if the current quip is not the noun: [do not advance these records if an NPC is merely replying to a topic the PC already introduced]
+	now break after reply is true;
+	if the current quip is not the noun and the noun is a quip: [Do not advance these records if an NPC is merely replying to a topic the PC introduced.]
 		now the grandparent quip is the previous quip;
 		now the previous quip is the current quip;
 		now the current quip is the noun.
 
+
+Chapter 3 - Tailored error messages
+
+Discussing is verbalizing. Discussing something with is verbalizing.
+
+Before doing something with a quip (this is the quips are not tangible rule):
+	unless we are verbalizing, say "[text of  parser error internal rule response (A)][line break]" (A) instead; ['I didn't understand that sentence.']
+	continue the action.
+
+Rule for printing a parser error when the latest parser error is the can't see any such thing error (this is the quips are not visible rule):
+	if the player's command includes "say/ask/answer/discuss/tell/a/t":
+		if the current interlocutor is a person and tc reparse flag is false:
+			say "That doesn't seem to be a topic of conversation at the moment." (A) instead;
+		otherwise:
+			unless the player's command includes "[any person]":
+				say "[We] [aren't] talking to anyone." (B) instead; ['You aren't talking to anyone.']
+	make no decision.
+
+Rule for printing a parser error when the latest parser error is the noun did not make sense in that context error (this is the prevent context error rule):
+	if (the player's command includes "say/ask/answer/discuss/tell/a/t"[ or the player's command includes "[any quip]"]) and the current interlocutor is not nothing:
+		say "[text of parser error internal rule response (N)][line break]" (A) instead; ['Not a verb I recognize.']
+	otherwise:
+		make no decision.
+
 Section 3 - The Player Discussing
 
 Check discussing (this is the cannot talk without an interlocutor rule):
-	if the current interlocutor is not a person:
-		say "You're not currently talking to anyone." instead.
+	unless the current interlocutor is a person:
+		if how-many-people-here is 1:
+			try discussing the noun with entry 1 of people-present instead;
+		otherwise:
+			say "[We]['re not] talking to anyone right [now]." (A) instead.
 
 Carry out discussing (this is the stop any planned casual follow-ups rule):
 	[unless addressing everyone is true:]
@@ -768,7 +817,7 @@ Section 4 - Other People Discussing
 
 [Check someone discussing something when the player can see the actor (this is the move interlocutors rule):
 	now the actor is the current interlocutor.]
-	
+
 Carry out someone discussing (this is the everyone has heard rule):
 	[now every person who can see the person asked recollects the noun.]
 	if  the actor is marked-visible:
@@ -781,7 +830,7 @@ Carry out someone discussing something which is not quippishly-relevant (this is
 
 Carry out someone discussing a one-time quip which quip-supplies the current interlocutor (this is the eliminate used quips rule):
 	now the noun is nowhere; [This is so that we are steadily whittling away from the quip-repository any unnecessary single-use quips]
-	
+
 Report someone discussing something (this is the interlocutor's reply rule):
 	if the noun provides the property reply:
 		say "[reply of the noun][paragraph break]".
@@ -1063,14 +1112,18 @@ Avoiding talking heads is an activity. [This is where we put in some kind of sce
 
 Section 5 - Weak phrasing
 
-A quip can be strongly-phrased or weakly-phrased. A quip is usually strongly-phrased. [* A quip may be designated "weakly-phrased" if we want to allow the interlocutor to transition smoothly into another line of conversation without a paragraph break. This is completely at the discretion of the author, and if it's left out, nothing bad results.]
+A quip can be strongly-phrased or weakly-phrased. A quip is usually strongly-phrased.
+
+[* A quip may be designated "weakly-phrased" if we want to allow the interlocutor to transition smoothly into another line of conversation without a paragraph break. This is completely at the discretion of the author, and if it's left out, nothing bad results.]
 
 Rule for avoiding talking heads (this is the default pause-construction rule):[* If the current quip from which we are building is weak, we want to fold it into one continuous paragraph with one intervening beat.]
 	if the current interlocutor is a person and the current interlocutor is ready for transition:
 		if the current quip is strongly-phrased and a random chance of 1 in 2 succeeds:
 			say "[beat][line break][paragraph break]";
 	otherwise:
-		say "[beat][if a random chance of 1 in 2 succeeds] [run paragraph on][otherwise][line break][paragraph break][end if]". [* This generates text that is printed between lines of conversation when the conversation is supposed to pause for a bit. The complexity of the structure is so that it can produce not-completely-predictable text structures. Specifically, an NPC's comment can either be beat-opened (an ugly term, I know) or not. If it is, that indicates that the comment begins with its own special, handwritten beat; in that case, we don't need to generate a grounding beat every time before we print it. If, however, the NPC's comment begins with quoted text, we do want a beat to separate it from the quoted text that preceded.]
+		say "[beat][if a random chance of 1 in 2 succeeds] [run paragraph on][otherwise][line break][paragraph break][end if]".
+
+[* This generates text that is printed between lines of conversation when the conversation is supposed to pause for a bit. The complexity of the structure is so that it can produce not-completely-predictable text structures. Specifically, an NPC's comment can either be beat-opened (an ugly term, I know) or not. If it is, that indicates that the comment begins with its own special, handwritten beat; in that case, we don't need to generate a grounding beat every time before we print it. If, however, the NPC's comment begins with quoted text, we do want a beat to separate it from the quoted text that preceded.]
 
 Report someone discussing a weakly-phrased dead-ended quip when the current interlocutor is a person and the current interlocutor is likely to continue and addressing everyone is false:
 	if the noun provides the property reply:
@@ -1086,7 +1139,13 @@ Rule for beat-producing (this is the default beat rule):
 
 Volume 5 - Conversational Pragmatics
 
-Book 1 - Ignorance
+Book I - Asking An NPC To Discuss
+
+Before asking someone to try verbalizing (this is the correct indirect instructions rule):
+	if the current interlocutor is not the person asked, implicitly greet the person asked;
+	try discussing the noun instead.
+
+Book 2 - Ignorance
 
 Expressing ignorance by something is an activity.
 
@@ -1126,11 +1185,14 @@ Carry out changing the subject (this is the standard report other subjects rule)
 
 Book 3 - Starting a Conversation
 
-Section 1 - Reparse after chatting (for use with Smarter Parser by Aaron Reed)
+tc reparse flag is a truth state that varies. [Whether we need to reparse the command after implicitly greeting someone and resetting quips' availability]
+
+Section 1 - Reparse after chatting
 
 Definition: a person is talk-ineligible if it is not talk-eligible.
 
 Understand "ask [someone talk-ineligible] about [text]" as starting a conversation with it about.
+Understand "ask [someone talk-ineligible] for [text]" as starting a conversation with it about.
 Understand "tell [someone talk-ineligible] about [text]" as starting a conversation with it about.
 
 Starting a conversation with it about is an action applying to one thing and one topic.
@@ -1141,11 +1203,11 @@ Carry out starting a conversation with it about:
 	implicitly greet the noun;
 	if the noun is the current interlocutor:
 		follow the relabel available quips rule;
-		now the reborn command is the substituted form of "[player's command]";
-		now sp reparse flag is true.
-	
-Understand "ask [a talk-eligible person] about [text]" as asking it about.
-Understand "tell [a talk-eligible person] about [text]" as telling it about.
+		now tc reparse flag is true.
+
+Rule for reading a command when tc reparse flag is true (this is the reset after retrying input rule):
+	now tc reparse flag is false;
+[	showme the current action;]
 
 Book 4 - Conversing
 
@@ -1154,6 +1216,7 @@ Book 4 - Conversing
 Asking someone about something is conversing.
 Telling someone about something is conversing.
 Answering someone that something is conversing.
+Asking someone for something is conversing.
 
 Before conversing when the noun is the player (this is the no talking to yourself rule):
 	say "There's no need to talk to yourself." instead.
@@ -1170,7 +1233,7 @@ Rule for reading a command when last command is not "" (this is the re-reading i
 
 A first turn sequence rule when the last command is not "" (this is the stop the turn sequence if re-checking input rule):
 	rule succeeds.
-	
+
 last command is text that varies.
 
 Before showing something to someone when the second noun is not the current interlocutor (this is the showing needs an interlocutor rule):
@@ -1267,6 +1330,8 @@ To set the current/-- interlocutor to (N - a person):
 To reset the interlocutor:
 	unless the current interlocutor is nothing:
 		truncate the planned conversation of the current interlocutor to 0 entries;
+	now the quip-repository is nowhere;
+	now available-subjects is {};
 	now the current interlocutor is nothing;
 	now the current quip is generic-quip;
 	now the previous quip is generic-quip.
@@ -1279,7 +1344,7 @@ Saying goodbye to is an action applying to one visible thing.
 
 Understand "say bye/goodbye/farewell/cheerio to [someone]" as saying goodbye to.
 
-Check saying goodbye to something when the noun is not the current interlocutor (this is the can't say goodbye to someonfe you're not talking to rule):
+Check saying goodbye to something when the noun is not the current interlocutor (this is the can't say goodbye to someone you're not talking to rule):
 	if addressing everyone is true:
 		say "You're not talking exclusively to [the noun]." instead;
 	otherwise:
@@ -1353,7 +1418,7 @@ and menu-based conversation, where the player is offered a list of things to say
 	2) Tell Jill that the chicken coop was robbed.
 
 or, sometimes,
-	
+
 	1) "Jill, have you seen your no-good layabout brother Jack anywhere?"
 	2) "Look, Farmer Jill, I think a fox got into the chickens."
 
@@ -1474,7 +1539,7 @@ Then we could write
 	The reply is "'I really don't know,' says [the current interlocutor].'"
 
 And now (assuming that the quip is otherwise an appropriate thing to say at this juncture) the player can cause this quip with any of
-	
+
 	>ask fred about the weather
 	>ask fred about rain
 	>ask fred about storms
@@ -1556,14 +1621,14 @@ We might implement such a system like this:
 
 	Check remembering:
 		if the number of quips which are recollected by someone is 0, say "You have not yet had any conversations to remember." instead.
-	
+
 	Carry out remembering:
 		let N be 0;
 		repeat with item running through quips which mention the noun:
 			increase N by 1;
 			if someone recollects the item, say "You have discussed '[the item]' with [the list of other people who recollect the item].";
 		if N is 0, say "You haven't discussed [the noun] with anyone yet."
-	
+
 	Definition: a person is other if he is not the player.
 
 With just these structures, we could already write a game in which the player can ask various characters about a wide range of topics, follow up with further quips, and review important questions that he's already asked. But there is much more that we can do by keeping track of the context of the conversation:
@@ -1654,7 +1719,7 @@ There are, as usual with rulebooks, numerous ways to tamper with all this. We ma
 		if greeting is not happening, it is off-limits.
 
 to use a quip only during a particular scene;
-	
+
 	Availability rule for what was cost of building ark:
 		if the player does not know flood-imminent, it is off-limits.
 
@@ -1689,7 +1754,7 @@ The mid-thread plausibility rule checks whether a quip falls outside the current
 	If we are currently discussing a quip that indirectly-follows other quips, we're construed to be in the middle of a thread. If not, anything can happen, so we skip the rest of the criteria. But if so:
 
 	A quip that belongs to the same thread -- that indirectly-follows one of the things we've just been talking about -- is not a change of subject. Such a quip is defined to be "quippishly-relevant".
-	
+
 	A quip that doesn't indirectly-follow any other quips (defined as "shallowly-buried") is understood to be the beginning of a new thread, so that's not marked as implausible either (though see the next rule).
 
 	But we do mark implausible a quip that indirectly-follows other quips -- that is, is deep in its own thread -- but doesn't belong to the thread we're currently on.
@@ -1728,7 +1793,7 @@ On a smaller scale, we can modify the output of the offer hint quips rule on a c
 	listing matched quips
 	listing plausible quips
 	listing peripheral quips
-	
+
 Listing matched quips forms the question Inform asks when disambiguating between several quips the player might want to say.
 
 Listing plausible quips forms the "You could..." line.
@@ -1787,7 +1852,7 @@ Very often in the course of the conversation we will want to add new items to a 
 	proceed to (some quip) [that is, queue this quip and then follow the character pursues own idea rule *immediately*, so that we get a pause followed by this new piece of conversation]
 
 All of these can be used within say tokens, as in
-	
+
 	say "'The weather is fine,' says Captain Hook. [queue picnic-proposal]".
 
 Section: Interrupting between the comment and the reply
@@ -1798,7 +1863,7 @@ If we want a character to respond atypically -- for instance, by ignoring all of
 
 	Procedural rule during Shadows:
 		substitute the distracted reply rule for the prepare a reply rule.
-	
+
 	This is the distracted reply rule:
 		if the person asked is not the player, make no decision;
 		if the noun is not quippishly-relevant:
@@ -1825,7 +1890,7 @@ If we want to queue something for the current interlocutor to say, we can write,
 
 If we wanted to have one piece of conversation give the character an idea for something to say later, we might write
 
-	Carry out Lily discussing why-Ireland:	
+	Carry out Lily discussing why-Ireland:
 		queue madhouses worse than prisons.
 
 -- though TC provides a shortcut for this that we can fold into spoken comments and replys. If we do
@@ -1915,7 +1980,7 @@ In this example, quips mention both things in the real world (the barmaid) and c
 	Include Threaded Conversation by Emily Short.
 
 	Section 1 - Model world
-	
+
 	When play begins:
 		say "It is a long and riotous evening, full of unlikely stories and tall tales. But now most of the patrons have gone away to their rooms to sleep, or have passed out before the fire. Even the two black bitch pups are curled on the hearth-stone, snuffling through tiny wet noses, and pawing the air in sleep. Now is the time to find out whether the rumors that brought you to this neighborhood are true."
 
@@ -1937,7 +2002,7 @@ In this example, quips mention both things in the real world (the barmaid) and c
 		It mentions immortality, rumors.
 		The comment is "'Where I come from, over the black hills there, they say that men this side of the mountain live as old as Methuselah,' you remark. 'They say the secret of eternal life is here.'".
 		The reply is "'Oh, do they?' she says, sweeping crumbs of cheese and crusty bread into her hand. 'The oldest codger around these parts is old Garrick, and I wouldn't put him beyond his four-score and ten.'".
-	
+
 	where Garrick lives is a questioning quip.
 		It mentions Old Garrick.
 		The comment is "'Where does this old Garrick live?' you ask, trying not to seem too eager.".
@@ -1949,7 +2014,7 @@ In this example, quips mention both things in the real world (the barmaid) and c
 		It mentions barmaid.
 		The comment is "'What about yourself?' you ask. 'Are you from around these parts?'"
 		The reply is "'If by these parts you mean between the black hills and the river, no,' she says. 'I was born just at the far side of the ford. But I came over here to work.'"
-	
+
 	whether she's heard the stories is a questioning quip.
 		It mentions barmaid, immortality, rumors.
 		The comment is "'Have you heard any stories of long-living men?' you press her."
@@ -1971,7 +2036,7 @@ Now we add a second character, a wanderer who has stopped at the inn for the eve
 	Include Threaded Conversation by Emily Short.
 
 	Section 1 - Model world
-	
+
 	When play begins:
 		say "It is a long and riotous evening, full of unlikely stories and tall tales. But now most of the patrons have gone away to their rooms to sleep, or have passed out before the fire. Even the two black bitch pups are curled on the hearth-stone, snuffling through tiny wet noses, and pawing the air in sleep. Now is the time to find out whether the rumors that brought you to this neighborhood are true."
 
@@ -1999,7 +2064,7 @@ Now we add a second character, a wanderer who has stopped at the inn for the eve
 		It mentions immortality, rumors.
 		The comment is "'Where I come from, over the black hills there, they say that men this side of the mountain live as old as Methuselah,' you remark. 'They say the secret of eternal life is here.'"
 		The reply is "[if the current interlocutor is the barmaid]'Oh, do they?' she says, sweeping crumbs of cheese and crusty bread into her hand. 'The oldest codger around these parts is old Garrick, and I wouldn't put him beyond his four-score and ten.'[otherwise]'That's true enough,' says [the current interlocutor]. 'Though there are plenty around here that will deny it.'[end if]".
-	
+
 	where Garrick lives is a questioning quip.
 		It mentions Old Garrick.
 		The comment is "'Where does this old Garrick live?' you ask, trying not to seem too eager.".
@@ -2012,14 +2077,14 @@ Now we add a second character, a wanderer who has stopped at the inn for the eve
 		The comment is "'What about yourself?' you ask. 'Are you from around these parts?'".
 		The reply is "'If by these parts you mean between the black hills and the river, no,' she says. 'I was born just at the far side of the ford. But I came over here to work.'"
 		It quip-supplies the barmaid.
-	
+
 	whether she's heard the stories is a questioning quip.
 		It mentions barmaid, immortality, rumors.
 		The comment is "'Have you heard any stories of long-living men?' you press her.".
 		The reply is "She pinches her lips and scrubs at a circle-shaped stain on the table before her. 'If you're a fool come looking for a spring of life or a vein of immortal gold buried in the black hills, you'd do better to go back home where you come from.'"
 		It indirectly-follows whether the rumors tell truly.
 		It quip-supplies the barmaid.
-	
+
 	Test one with "talk to the barmaid / ask the barmaid about rumors / ask about garrick / talk to the wanderer / ask him about the rumors".
 
 Notice how both the barmaid and the wanderer can answer the first quip (and, using text variations, answer it in different ways); but only the barmaid knows about the last three quips, thanks to the quip-supplying relation.
@@ -2033,7 +2098,7 @@ Here we're going to let the player ask the wanderer the same question several ti
 	Include Threaded Conversation by Emily Short.
 
 	Section 1 - Model world
-	
+
 	When play begins:
 		say "It is a long and riotous evening, full of unlikely stories and tall tales. But now most of the patrons have gone away to their rooms to sleep, or have passed out before the fire. Even the two black bitch pups are curled on the hearth-stone, snuffling through tiny wet noses, and pawing the air in sleep. Now is the time to find out whether the rumors that brought you to this neighborhood are true."
 
@@ -2061,7 +2126,7 @@ Here we're going to let the player ask the wanderer the same question several ti
 		It mentions immortality, rumors.
 		The comment is "'Where I come from, over the black hills there, they say that men this side of the mountain live as old as Methuselah,' you remark. 'They say the secret of eternal life is here.'"
 		The reply is "[if the current interlocutor is the barmaid]'Oh, do they?' she says, sweeping crumbs of cheese and crusty bread into her hand. 'The oldest codger around these parts is old Garrick, and I wouldn't put him beyond his four-score and ten.'[otherwise]'That's true enough,' says [the current interlocutor]. 'Though there are plenty around here that will deny it.'[end if]".
-	
+
 	where Garrick lives is a questioning quip.
 		It mentions Old Garrick.
 		The comment is "'Where does this old Garrick live?' you ask, trying not to seem too eager.".
@@ -2074,14 +2139,14 @@ Here we're going to let the player ask the wanderer the same question several ti
 		The comment is "'What about yourself?' you ask. 'Are you from around these parts?'".
 		The reply is "'If by these parts you mean between the black hills and the river, no,' she says. 'I was born just at the far side of the ford. But I came over here to work.'"
 		It quip-supplies the barmaid.
-	
+
 	whether she's heard the stories is a questioning quip.
 		It mentions barmaid, immortality, rumors.
 		The comment is "'Have you heard any stories of long-living men?' you press her.".
 		The reply is "She pinches her lips and scrubs at a circle-shaped stain on the table before her. 'If you're a fool come looking for a spring of life or a vein of immortal gold buried in the black hills, you'd do better to go back home where you come from.'"
 		It indirectly-follows whether the rumors tell truly.
 		It quip-supplies the barmaid.
-	
+
 	what he knows is a questioning quip.
 		It mentions rumors, wanderer.
 		The comment is "[one of]'What do you know about those who live forever?' you ask[or]'Tell me more about the secrets of eternal life concealed here,' you plead[stopping]."
@@ -2097,7 +2162,7 @@ Here we're going to let the player ask the wanderer the same question several ti
 		The reply is "'Why not?' He searches through the pockets of his coat, and then the pockets of his trousers, and finally -- looking surprised and much relieved -- finds what he was looking for tucked away in his boot. 'Here it is: have a look.' [paragraph break]And he extends for view an old-fashioned locket: painted on an ivory rectangle are the images of two young men. They are painted so small that it would be hard to guarantee that you would recognize them again."
 		It quip-supplies the wanderer.
 		It indirectly-follows what he knows.
-	
+
 	Test me with "talk to the wanderer / ask him about the rumors / ask what he knows / g / g / g / ask whether I may see the miniature".
 
 Notice that we are allowed to ask the "what he knows" quip a number of times, but that after the first time of asking, it stops being suggested to the player: the "you could ask..." sentence only suggests things that the player hasn't tried yet. This is one of several reasons why we shouldn't hide new information in the later stages of the same quip. If we want to give the player more information about a subject, we should make separate quips. Having a repeatable quip is useful mostly in that it lets the player hear again information that he might have forgotten and that is vital to the progress of the game.
@@ -2119,7 +2184,7 @@ We also do not provide any cues about special things to say, and we avoid using 
 	Include Threaded Conversation by Emily Short.
 
 	The Black Palace is a room. The King of Everything is here.
-	
+
 	Quips are usually repeatable.  The offer hint quips rule is not listed in any rulebook.
 
 	Instead of discussing something which is recollected by the current interlocutor:
@@ -2127,7 +2192,7 @@ We also do not provide any cues about special things to say, and we avoid using 
 	Who is a subject.
 
 	[The following quip was automatically built with Conversation Builder, though we could have written it by hand. Notice that we use printed name to avoid having the word "is" as part of the quip name; this confuses Inform at compilation time.]
-	
+
 	who he seems is a questioning quip.
 		The printed name is "who he is". The true-name is "who he seems".
 		Understand "is" as who he seems.
@@ -2147,7 +2212,7 @@ To keep this example simple, we will have just one piece of information that cou
 To do this, we add a "characters think rule", which we call once before the active conversation rule (that is, before the current interlocutor has a chance to respond to us) and once at the end of the conversation-reply rules (after the current interlocutor has said anything she is going to say). We could write any amount of reasoning into the characters think rule, even allowing them to draw complicated conclusions from facts.
 
 The specific quips are once again generated by Conversation Builder.
-	
+
 	*: "Conferences"
 
 	Include Threaded Conversation by Emily Short.
@@ -2157,13 +2222,13 @@ The specific quips are once again generated by Conversation Builder.
 	Thurg is a man in the Conference Chamber. Lavine is a woman in the Conference Chamber.
 
 	The characters think rule is listed before the active conversation rule in the every turn rules.
-	
+
 	This is the characters think rule:
 		repeat with item running through people who are not the player:
 			consider the thinking rules for the item.
-	
+
 	A conversation-reply rule:
-		follow the characters think rule.	
+		follow the characters think rule.
 
 	The thinking rules are an object-based rulebook.
 


### PR DESCRIPTION
An attempt to speed up the conversation system, mainly by reducing the number of quips checked for availability each turn and changing the way parsing of things mentioned by quips work. Some more code from Chris Conley's later version of Threaded Conversation was also transplanted into ours.

It seems to be quite a bit faster, especially when asking about unimplemented things and typing other things that are not the suggested quips, such as TALK TO BARKER when first meeting him or ASK FARMER ABOUT YAM.