### PR TITLE
Nicer line breaks around achievement messages

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -2580,7 +2580,7 @@ Report inserting the god into the shrine:
 For a moment, with the air still and hot, and no one visible in any direction, we might almost believe that the past two millennia have been nothing, and that the shrine is fresh and new.
 
 But Anglophone Atlantis prefers to forget what it was.";
-	record "Jocasta Higgate award for reconstructing pagan worship on the island" as an achievement instead.
+	record "Jocasta Higgate award for reconstructing pagan worship on the island" as an achievement with break before instead.
 
 Report inserting something into the shrine:
 	say "[We] give [the noun] a place of solemn hon[our] above the relief of frolicking ladies." instead.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
@@ -163,12 +163,12 @@ Equipment Archive is a room. It is indoors, forbidden and southern. The descript
 A ceiling mirror is a mirror in the Equipment Archive.
 
 Instead of shooting a mirror with the loaded anagramming gun:
-	record "Finn Rosehip award for gnu-hunting" as an achievement;
 	say "[We] fire the anagramming gun into [the noun]. The reflection at once converts the anagramming gun into an anagramming gnu.
 
 The gnu stares around in confusion, its watery gaze temporarily dissolving everything it looks at, until at last it happens to catch its own reflection.
 
-A moment later, the anagramming gun is merely a gun again."
+A moment later, the anagramming gun is merely a gun again.";
+	record "Finn Rosehip award for gnu-hunting" as an achievement with break before.
 
 Some equipment shelves are a supporter in Equipment Archive. The initial appearance is "[The shelves] here display an assortment of obsolete, broken, foreign, or otherwise unusual letter tools."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Presentation Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Presentation Details.i7x
@@ -407,7 +407,16 @@ To record (slug - some text) as an achievement:
 		choose a blank row in the Table of Possible Achievements;
 		now the achievement entry is N;
 		unless the location is nautical:
-			say "[first custom style][line break]Achievement accomplished: [N]![line break][roman type]";
+			say "[first custom style]Achievement accomplished: [N]![roman type][paragraph break]";
+	write File of Conclusions from the Table of Possible Achievements.
+
+To record (slug - some text) as an achievement with break before:
+	read the achievements;
+	let N be "[slug]";
+	unless N is a used achievement:
+		choose a blank row in the Table of Possible Achievements;
+		now the achievement entry is N;
+		say "[line break][first custom style]Achievement accomplished: [N]![roman type][paragraph break]";
 	write File of Conclusions from the Table of Possible Achievements.
 
 Table of Possible Achievements

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -1722,8 +1722,14 @@ The passage-place is a thing. The printed name is "passage". Understand "passage
 
 The Shadow Chamber is a room. It is indoors. The description is "Dim lights in the floor make it possible to navigate in here, though it's still fairly dark. The place is small and shabby, the air stale.[assign-amanda]".
 
+[Somewhat hackish way to get an extra line break before the achievement message and avoid a double paragraph break after]
 To say assign-amanda:
-	record "Amanda Waterstone award for discovering cultic passages" as an achievement.
+	let N be "Amanda Waterstone award for discovering cultic passages";
+	unless N is a used achievement:
+		choose a blank row in the Table of Possible Achievements;
+		now the achievement entry is N;
+		say "[paragraph break][first custom style]Achievement accomplished: [N]![roman type]";
+		write File of Conclusions from the Table of Possible Achievements.
 
 The Greek inscription is fixed in place in the shadow chamber.
 The initial appearance is "Cold water flows from a crack in the wall. Above it, words are carved: ΝΙΨΟΝ ΑΝΟΜΗΜΑΤΑ ΜΗ ΜΟΝΑΝ ΟΨΙΝ."
@@ -2168,7 +2174,7 @@ Sanity-check washing the pirate-crew:
 Instead of showing the spot to the pirate-crew:
 	now the pirate-crew is nowhere;
 	say "To a man, they turn white under their tans. Then they flee.";
-	record "Lord Michael Rosehip award for showing the black spot to a pirate crew" as an achievement.
+	record "Lord Michael Rosehip award for showing the black spot to a pirate crew" as an achievement with break before.
 
 Instead of smelling the pirate-crew:
 	say "They smell like a group that's spent months on a ship, living on a diet of watered rum and tortoise meat. Which is to say, I wish you wouldn't make me breathe so deeply."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -377,9 +377,7 @@ Carry out waving the letter-remover device at something:
 	carry out the caching scope activity with the player;
 	record "using the letter-remover" as achieved;
 	let current be the current setting of the letter-remover;
-	remove current from the list of remaining letters, if present;
-	if the number of entries in the list of remaining letters is 0:
-		record "Admiral Thoureaux award for removing every letter of the alphabet in one playthrough" as an achievement;
+	remove current from the list of remaining letters, if present.
 	[add the current setting of the letter-remover to the list of removed letters, if absent. ]
 
 The list of remaining letters is a list of text that varies. The list of remaining letters is { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"}.
@@ -390,6 +388,11 @@ Report waving the letter-remover device at something:
 		say "With a distinct whiff of [the scent-description of the generated object], [the second noun] [turn] into [a generated object]. [run paragraph on]";
 	otherwise:
 		say "There is [one of]a flash of psychedelic col[our]s[or]a mad-scientist cackle[or]a [pastel-color] cloud[or]a flash of [primary-color] light[or]a smell of anise[or]a distinct spearmint flavor[at random], and [the second noun] [turn] into [a generated object]. [run paragraph on]";
+	if the number of entries in the list of remaining letters is 0:
+		let N be "Admiral Thoureaux award for removing every letter of the alphabet in one playthrough";
+		unless N is a used achievement:
+			say paragraph break;
+			record N as an achievement;
 	abide by the dangerous construction rules for the generated object;
 	try examining the generated object instead.
 


### PR DESCRIPTION
This goal here is to always have exactly one paragraph break before and one paragraph break after every "Achievement accomplished" message.

It adds an alternative way of announcing achievements with a line break before the message, and a couple of special cases. I'm sure there are still situations where this will break, but I haven't found any so far.

Note that the full-game achievements, such as "Alex Rosehip award for completing the game in easy mode," are never actually announced, for aesthetic reasons. This is old behavior that is not changed by this pull request.
