### PR TITLE
New conversation speed hacks.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
@@ -670,8 +670,14 @@ After reading a command when location is Counterfeit Monkey (this is the replace
 
 The barman is a man in Counterfeit Monkey. The description of the barman is "His name is Parker, and he is a friend of yours, when you're wearing your own skin. At the moment, though, it seems like a good idea not to trust these friendships by making our new disguise known." Understand "bartender" or "barkeep" or "Parker" as the barman.
 
+Instead of starting a conversation with the barman about something in the presence of Slango:
+	say "Better not; the less people notice this little conversation, the better."
+
 Instead of saying hello to the barman in the presence of Slango:
 	say "Better not; the less people notice this little conversation, the better."
+
+Check starting a conversation with clientele about something:
+	say "They're... busy. At best interrupting them would interrupt their code, and at worst it would make them think [we] [are] a Bureau agent." instead.
 
 Instead of saying hello to the clientele:
 	say "They're... busy. At best interrupting them would interrupt their code, and at worst it would make them think [we] [are] a Bureau agent."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Character Models.i7x
@@ -303,15 +303,11 @@ Check saying hello to someone who is not the current interlocutor when the curre
 	otherwise:
 		say "[The noun] [are] already included in the conversation." instead.
 
-Check starting a conversation with clientele about something:
-	say "They're... busy. At best interrupting them would interrupt their code, and at worst it would make them think [we] [are] a Bureau agent." instead.
-
 Test clientele-bug with "ask parker about slango / ask men about slango" in the Counterfeit Monkey.
 
 Carry out starting a conversation with an eavesdropping person about when the current interlocutor is a person:
 	say "[We] give [the noun] a look to say [their] input would be welcome as well.";
-	now the reborn command is the substituted form of "ask about [topic understood]";
-	now sp reparse flag is true instead.
+	try subject-asking the second noun instead.
 
 [We do want it to be possible for the player to say "hi" back to a character who has just greeted him if the conversation has just started.]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -49,7 +49,7 @@ The stripping body parts rule is not listed in any rulebook. [We don't want the 
 The offer new prompt rule is not listed in any rulebook.
 
 Before reading a command when tutorial mode is true (this is the alternate new prompt rule):
-	if sp reparse flag is false and tc reparse flag is false and identification is not happening:
+	if sp reparse flag is false and identification is not happening:
 		follow the instructional rules.
 
 The new stripping adverbs rule is listed instead of the stripping adverbs rule in the Smarter Parser rulebook.


### PR DESCRIPTION
Let's make the most complicated code in this game even more so. This is the result of careful profiling of different methods, and seems on average to give a good speed up without sacrificing functionality.

Mostly this concerns the fairly rare case when we explicitly start a new conversation with somebody. Usually the game does this automatically for us when we enter a room with a character in it, except with the desk attendant in the hostel and the farmer at Hesychius road. These two could cause quite long pauses if we began the conversation by typing something like ASK ABOUT YAM or ASK ATTENDANT ABOUT INTERNET, or it would simply give the error "We aren't talking to anyone."

This code introduces the predicted-interlocutor global variable, which is set in the presence of these two people, and the same sorting of quips takes place as when setting the current interlocutor.