### PR TITLE
Restore Notepad to its original glory.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -1276,8 +1276,7 @@ Instead of smelling the Projection Booth:
 	say "The ghost of hot dog and relish lingers in the air. It's mildly nauseating."
 
 The jotter is a notepad in the Projection Booth. The initial appearance is "[A jotter] is propped up next to the projector." The description is "It's a little spiral-bound notebook, the kind reporters in old movies carry. It's full of notes: running times of movies. Numbers of people in the audience. Who clapped during potentially subversive scenes. Who arrived in a group of more than three."
-	The jotter write-allows a pen and some pens.
-	The memo of the jotter is "Red: audience 14. FM couple. MM couple. M in raincoat. FFFFF group. F. MF. M.".
+	The memo of the jotter is "Red: audience 14. FM couple. MM couple. M in raincoat. FFFFF group. F. MF. M.". The allowed-pens of jotter is {pen, some pens}.
 
 Rule for writing a topic sentence about the jotter when the projector is mentionable:
 	say "[A jotter] is propped up next to [the projector].[no line break]"

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
@@ -1863,7 +1863,7 @@ The podium is a supporter in Lecture Hall 1. It is scenery. The description is "
 
 On the podium is a page. The page is a notepad. The description of the page is "A sheet of lined paper[if the location is Lecture Hall 1], presumably left by the person who lectured here last[end if]."
 	The memo of the page is "visual[ization] training... preparation at a young age... cooperative direction of language outcomes".
-	The page write-allows a pen and some pens. Understand "paper" as the page.
+	Understand "paper" as the page. The allowed-pens of the page is {pen, some pens}.
 
 A description-concealing rule when the page is marked for listing:
 	if the page is not seen and the page is not handled:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -1687,8 +1687,7 @@ The papas are a man. The description of the papas is "A whole fatherly fleet, ta
 	The greeting of the papas is "'Good to see you, my dear,' says one of the papas. 'But I doubt our conversation can interest you.' And he turns back to one of the others, speaking in a hushed voice of [one of]Disraeli[or]Mrs Brown[or]those scandalous deaths in Whitechapel[or]the installation of the underground trains[at random]."
 
 The paper is a notepad. The description of the paper is "It contains a memo, dated to May of 1983. 'Attention,' it says. 'Due to subversive counter-propaganda altering the abstract concept, Subject A must NO LONGER BE GELLED AFTER USE, since reconstructing her may produce anomalous results. She will from now on be housed in a continuous living state in the historic apartments.'"
-	The paper write-allows some pens and a pen.
-	The scent-description of the paper is "purple ink".
+	The scent-description of the paper is "purple ink". The allowed-pens of paper is {pen, some pens}.
 
 The description of the paper-model is "There's now just one model of the New Church remaining, but it's a doozy, with card stock pews and interior decor to assemble before you get to the outside portion." The printed name of the paper-model is "paper model". Understand "model" or "paper model" as the paper-model.
 
@@ -1711,10 +1710,9 @@ The description of the pass is "A Bureau of Orthography visiting pass, a very va
 The description of the passcard is "A variant of a passport: it has an image on the front that looks more or less like us, though with more hair, and the stripe on the back is imprinted, presumably, with various biometric information. It's no good at unlocking doors, however."
 	The scent-description of the passcard is "plastic".
 
-The passage is a notepad. The heft of the passage is 1. The description of the passage is "A short piece of prose neatly letterpressed onto a large sheet of paper. It reads:
+The passage is a notepad. The allowed-pens is {pen, some pens}. The heft of the passage is 1. The description of the passage is "A short piece of prose neatly letterpressed onto a large sheet of paper. It reads:
 
 [i]The alphabet is a system of interchangeable parts. The word form can be surgically revised, instead of rewritten, to become the word farm or firm or fork or fort or from, or with a little more trouble, to become the word pineapple. [--] Robert Bringhurst[/i]".
-	The passage write-allows a pen and some pens.
 
 The passage-place is a thing. The printed name is "passage". Understand "passage" or "corridor" as the passage-place. The heft of the passage-place is 10. The passage-place is fixed in place. The description is "It's a dark, stone-lined corridor leading into the earth." The initial appearance is "A passage lined in stone descends into the face of [the programmable dais]."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Major Contents.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Major Contents.i7x
@@ -560,7 +560,7 @@ The repository contains a pita, a pit, a PTA, an it-object, a pa, a pi-object, a
 
 [plans]
 In the repository are some iron-pans, a plan, an i-pan,
-	some pens, a pen, some pins, a pin, a pi-object, a pun, some puns, [vowel rotation]
+	[some pens, a pen,] some pins, a pin, a pi-object, a pun, some puns, [vowel rotation]
 	some plants, a plant, a pant, a pint, some pints, a fake-punt, some punts, [t-insert derivatives]
 	some pants, some plats, a plat, a pat, a pit, some pit-items, some pat-items, an ant, a pus, [derive insertions]
 	a snap, an alterna-snap, a nap, a splat, a tap, a spit, a spat, a tan, [anagram all]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -2018,6 +2018,8 @@ I didn't really greatly want to develop that from scratch, but happily an extens
 
 Include Notepad by Jim Aikin.
 
+The repository contains a pen and some pens.
+
 Understand "write on [something]" as a mistake ("You'll need to say what you want to write down, as in 'write Alice on [the noun]'.").
 
 Understand "write with [something]" as a mistake ("You'll need to say what you want to write down, as in 'write Alice on [the random notepad]'.").

--- a/Counterfeit Monkey.materials/Extensions/Jim Aikin/Notepad.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Jim Aikin/Notepad.i7x
@@ -1,16 +1,11 @@
-Version 4/160517 of Notepad by Jim Aikin begins here.
-
-[Updated allowed pens to be relation for Counterfeit Monkey, everything else broken - Petter Sjölund]
+Version 3 of Notepad by Jim Aikin begins here.
 
 "A system for creating an in-game notepad that the player can write on."
 
 Section 1 - Definitions
 
 
-A notepad is a kind of thing. A notepad has a text called memo. The memo of a notepad is usually "". A notepad has a truth state called pen-needed. The pen-needed of a notepad is usually true. A notepad can be edit-allowing or non-edit-allowing. A notepad is usually edit-allowing.
-
-write-allowing relates various notepads to various things. The verb to write-allow implies the write-allowing relation. 
-
+A notepad is a kind of thing. A notepad has a text called memo. The memo of a notepad is usually "". A notepad has a list of things called allowed-pens. The allowed-pens of a notepad is usually {}. A notepad has a truth state called pen-needed. The pen-needed of a notepad is usually true. A notepad can be edit-allowing or non-edit-allowing. A notepad is usually edit-allowing.
 
 Termination type is a kind of value. The termination types are terminated and unterminated.
 
@@ -91,7 +86,7 @@ Check an actor writing on something (this is the ordinary check writing it on ru
 		otherwise if the second noun is non-edit-allowing:
 			say "[The second noun] [are] [currently]write-protected, and [can't] be written on." (B) instead;
 		if the pen-needed of the second noun is true:
-			repeat with P running through things write-allowed by the second noun:
+			repeat with P running through the allowed-pens of the second noun:
 				if the player carries P:
 					now carrying-pen is true;
 		otherwise:
@@ -106,7 +101,7 @@ Check an actor writing on something (this is the ordinary check writing it on ru
 			say "[The second noun] [are] [currently]write-protected, and [can't] be written on." (E);
 			rule succeeds;
 		if the pen-needed of the second noun is true:
-			repeat with P running through things write-allowed by the second noun:
+			repeat with P running through the allowed-pens of the second noun:
 				if the actor carries P:
 					now carrying-pen is true;
 		otherwise:
@@ -138,7 +133,7 @@ Check an actor adding to something (this is the ordinary check adding it to rule
 		rule succeeds;
 	if the pen-needed of the second noun is true:
 		now carrying-pen is false;
-		repeat with P running through things write-allowed by the second noun:
+		repeat with P running through the allowed-pens of the second noun:
 			if the actor carries P:
 				now carrying-pen is true;
 	otherwise:
@@ -207,7 +202,7 @@ Check an actor copying something to something (this is the ordinary check copyin
 		say "At [that] moment, nothing [are] written on [the noun]." (G) instead;
 	if the pen-needed of the second noun is true:
 		now carrying-pen is false;
-		repeat with P running through things write-allowed by the second noun:
+		repeat with P running through the allowed-pens of the second noun:
 			if the player carries P:
 				now carrying-pen is true;
 	otherwise:
@@ -342,9 +337,9 @@ Version 3 is updated to work with Inform 6L38. The Check rules in Sections 4 and
 
 Section: Using Notepad.
 
-To use Notepad, first create a writing implement and a notepad. The writing implement is not a special kind of thing; anything can be a writing implement (for instance, a fountain pen, which might be implemented as a container that needs to be loaded with ink). Now the notepad write-allowes the writing implement:
+To use Notepad, first create a writing implement and a notepad. The writing implement is not a special kind of thing; anything can be a writing implement (for instance, a fountain pen, which might be implemented as a container that needs to be loaded with ink). Add the writing implement to the list of allowed-pens of the notepad:
 
-	The player carries a piece of chalk. The player carries a slate. The slate is a notepad. The slate write-allows the chalk.
+	The player carries a piece of chalk. The player carries a slate. The slate is a notepad. The allowed-pens of the slate is {chalk}.
 
 Any number of writing implements can be included in the allowed-pens list for a notepad. If you'd rather let the player write on the notepad without bothering with a writing implement (perhaps because the notepad object is a hand-held computer with a QWERTY keyboard), forget about the allowed-pens list. Instead, set the pen-needed property of the notepad to false:
 
@@ -406,9 +401,9 @@ Example: * Memorabilia - Some objects the player can write in.
 
 	The player carries a pencil and a piece of chalk.
 
-	The player carries a slate. The slate is a notepad. The description of the slate is "Black." The slate write-allows chalk.
+	The player carries a slate. The slate is a notepad. The description of the slate is "Black." The allowed-pens of the slate is {chalk}.
 
-	The player carries a notebook. The notebook is a notepad. The description of the notebook is "Dog-eared." The notebook write-allows pencil.
+	The player carries a notebook. The notebook is a notepad. The description of the notebook is "Dog-eared." The allowed-pens of the notebook is {pencil}.
 
 	The foggy mirror is in the Lab. The description is "The mirror [are] thickly coated with condensed steam." The foggy mirror is a notepad. The pen-needed of the foggy mirror is false. The memo of the foggy mirror is "Beware! Ghouls!"
 
@@ -436,7 +431,7 @@ Example: * Beethoven - A deaf NPC who responds only to commands written in the c
 
 	The Broadwood piano is scenery in the Messy Front Parlor. The description is "The piano is handsomely inlaid with fleur-de-lis." Understand "handsome", "inlay", and "fleur-de-lis" as the Broadwood piano. The Broadwood piano is a musical instrument.
 
-	The player carries a conversation book and a quill pen. The conversation book is a notepad. The conversation book write-allows quill pen. The description of the conversation book is "The deaf composer often used a book of this sort to hold conversations with his friends. They would write whatever they wanted to say to him in the book and then show him the book."
+	The player carries a conversation book and a quill pen. The conversation book is a notepad. The allowed-pens of the conversation book is {quill pen}. The description of the conversation book is "The deaf composer often used a book of this sort to hold conversations with his friends. They would write whatever they wanted to say to him in the book and then show him the book."
 
 	Section 2 - Beethoven
 
@@ -491,5 +486,3 @@ Example: * Beethoven - A deaf NPC who responds only to commands written in the c
 		say "You try a few tentative notes on [the noun], but it's in such poor condition that you desist almost before you start."
 
 	Test me with "show book to beethoven / write play the piano in the book / show book to beethoven / beethoven, play the piano / write go north in conversation book / show book to beethoven".
-	
-		


### PR DESCRIPTION
When I originally made this run on Inform 6M62, I couldn't get Notepad to accept the pen and the pens in its allowed-pens lists. In the end I just changed the list into a relation, with a penalty of increased memory usage and slower performance. It turns out it could be fixed by just moving the declaration of the pen and pens instead.