### PR TITLE
Fix #76, graphic links not working.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
@@ -21,6 +21,7 @@ The graphics window construction rule is not listed in any rulebook.
 When identification ends (this is the open the graphics window rule):
 	now current graphics drawing rule is the compass-drawing rule;
 	open the graphics window;
+	start looking for graphlinks.
 
 
 

--- a/Counterfeit Monkey.materials/Extensions/Emily Short/Glulx Entry Points.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Emily Short/Glulx Entry Points.i7x
@@ -84,7 +84,7 @@ Section - HandleGlkEvent routine
 
 Include (- Array evGlobal --> 4; -) before "Glulx.i6t".
 
-[Include (- 
+Include (-
 
   [ HandleGlkEvent ev context abortres newcmd cmdlen i ;
       for (i=0:i<3:i++) evGlobal-->i = ev-->i;
@@ -92,7 +92,7 @@ Include (- Array evGlobal --> 4; -) before "Glulx.i6t".
       return (+ value returned by glk event handling +) ;
   ];
 
--) before "Glulx.i6t".]
+-) before "Glulx.i6t".
 
 
 Section - Useful function wrappers


### PR DESCRIPTION
Small changes to fix #76 , see [my comments](https://github.com/i7/counterfeit-monkey/issues/76).

I'm not sure why HandleGlkEvent was commented out in the first place (in [3d67285](https://github.com/i7/extensions/commit/3d6728535c9637d5778d5e0d52d68f70938a3c36) ), so this might be bad in some way.