### PR TITLE
Make sure that the graphics window always has the right size. Fixes #80.

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
@@ -18,6 +18,35 @@ The position of the graphics window is g-placeleft.
 
 The graphics window construction rule is not listed in any rulebook.
 
+Before refreshing the graphics window:
+	if glulx graphics is supported:
+		adjust size of graphics window;
+	continue the activity.
+
+To force the percentage of (win - a g-window) to (percentage - a number):
+	(- glk_window_set_arrangement( glk_window_get_parent( {win}.(+ ref number +) ), winmethod_Left | winmethod_Proportional, {percentage}, GLK_NULL ); -).
+[ Note that this is currently hard-coded to use the winmethod_Left split method ]
+
+Ideal-size is a number that varies.
+
+To adjust size of graphics window:
+	force the percentage of graphics window to the measurement of the graphics window;
+	[ This changes the width of graphics window to 50 percent of total window ]
+	let size be the width of the graphics window;
+	now ideal-size is size;
+	if ideal-size > the maximum size of the graphics window:
+		now ideal-size is maximum size of the graphics window;
+	[ Currently maximum size of the graphics window is 722 pixels. This is large enough to never happen on most screens. ]
+	let real-ideal be 0.0;
+	now real-ideal is ideal-size;
+	let ratio be real-ideal divided by the height of the graphics window;
+	if ratio > 0.8395: [ Too low to show the entire map when scaled to window width ]
+		now ideal-size is (height of graphics window * 0.8395) to the nearest whole number;
+	if ideal-size is not size: [ The size has changed ]
+		force the size of graphics window to ideal-size;
+		redraw the map and compass;
+	update the status line.
+
 When identification ends (this is the open the graphics window rule):
 	now current graphics drawing rule is the compass-drawing rule;
 	open the graphics window;
@@ -291,7 +320,7 @@ Report looking (this is the update compass after looking rule):
 [We want the compass to stay down in a corner of the screen and not to scale up too huge if the screen is resized. One of the irritating things about Glulx window management is that it's impossible to force an aspect ratio on the player, so I have no idea whether they're going to go tall-and-skinny or short-and-wide. Testers playing in full-screen mode sometimes found that the compass got way too large and encroached on the upper part of the map if I just set the compass to be one quarter the width of the window.]
 
 To decide what number is grid-size:
-	let width-quarter be (the width of the graphics window / 4);
+	let width-quarter be (ideal-size / 4);
 	let height-quarter be (the height of the graphics window / 4);
 	if width-quarter is greater than height-quarter:
 		now compass width is height-quarter;
@@ -368,11 +397,11 @@ Figure of background colour is the file "map-background-colour.png".
 
 To redraw the map and compass:
 	if glulx graphics is supported:
-		clear the graphics window;
 		[ Draw the background at slightly more than half the window height to ensure odd heights don't leave a 1 pixel black line ]
+		let scaled-height be (ideal-size / 0.8395) to the nearest whole number;
 		let half height be (height of the graphics window / 2) + 1;
-		draw figure of background colour in graphics window at x 0 and y half height scaled to width (width of the graphics window) and height half height;
-		draw the local map of the location in graphics window;
+		draw figure of background colour in graphics window at x 0 and y half height scaled to width ideal-size and height half height;
+		draw the local map of the location in graphics window at x 0 and y ((height of the graphics window - scaled-height) / 2) scaled to width ideal-size and height scaled-height;
 		draw Figure of center-squiggle in graphics window at x x-coordinate of north and y y-coordinate of west scaled to width grid-size and height grid-size;
 		determine compass coordinates;
 		repeat with way running through directions:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
@@ -18,7 +18,7 @@ The position of the graphics window is g-placeleft.
 
 The graphics window construction rule is not listed in any rulebook.
 
-Before refreshing the graphics window:
+Before refreshing the graphics window (this is the adjust the graphics window to accommodate the map rule):
 	if glulx graphics is supported:
 		adjust size of graphics window;
 	continue the activity.


### PR DESCRIPTION
This adds a Before refreshing the graphics window rule that makes sure that the graphics window has the right proportions to show the entire map scaled to the full width of the graphics window.

Basically it first forces the width of the graphics window to half that of the total width of the parent game window (using a custom "force the percentage of (win - a g-window)" phrase), checks if this can accommodate the map, and if not, makes it narrower.

It is necessary to do it this way because Glk provides no way to directly get the width of the total game window in pixels.

This is tested on Gargoyle, Lectrote and Zoom.

The rule gets called four times every time the player adjusts the size of the window (but only two on Gargoyle for some reason), and I don't understand enough of Glk and Flexible windows to tell why. You'd think once would be enough. In some situations Zoom will flicker for a while between two different sizes in a very ugly way, but this does not seem to happen on Gargoyle or Lectrote.

It looks fine on Gargoyle, but Lectrote will draw ugly black padding around the map while the player resize-drags the window to enlarge it. I wonder if there is a way to make the entire graphics window black instead during resizing.

I have a feeling there are smarter ways to do this. Any suggestions are welcome.