### PR TITLE
Non-interactive profiling mode

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -302,7 +302,7 @@ Before taking inventory for the first time:
 
 A last when play begins rule (this is the initial conversation rule):
 	say "Can you hear me? >> [run paragraph on]";
-	if the player consents:
+	if now-autotesting is true or the player consents:
 		say "[line break]Good, you're conscious. We're conscious. ";
 	otherwise:
 		say "[line break]Ah, smartaleck. But we're conscious. ";
@@ -360,7 +360,9 @@ After reading a command during identification (this is the parse identification 
 			say "[banner text]";
 			say "[paragraph break]Let's try to get a look around. I haven't been able to run our body without your help, but maybe now you're awake, it'll work better.";
 		follow the scene changing rules;
-		reject the player's command.
+		unless now-autotesting is true:
+			reject the player's command.
+
 
 
 Section 2 - Tutorial Mode

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -302,7 +302,7 @@ Before taking inventory for the first time:
 
 A last when play begins rule (this is the initial conversation rule):
 	say "Can you hear me? >> [run paragraph on]";
-	if now-autotesting is true or the player consents:
+	if the player consents:
 		say "[line break]Good, you're conscious. We're conscious. ";
 	otherwise:
 		say "[line break]Ah, smartaleck. But we're conscious. ";
@@ -360,8 +360,7 @@ After reading a command during identification (this is the parse identification 
 			say "[banner text]";
 			say "[paragraph break]Let's try to get a look around. I haven't been able to run our body without your help, but maybe now you're awake, it'll work better.";
 		follow the scene changing rules;
-		unless now-autotesting is true:
-			reject the player's command.
+		reject the player's command;
 
 
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Schedule and Time.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Schedule and Time.i7x
@@ -822,7 +822,7 @@ Brock studies us for a moment more. Then he reaches into his pocket and pulls ou
 'Want one? They used them as packing material in my shipping box. We've got lots.'"
 
 
-The print the final question rule response (A) is "[full-game achievements]Would you like to "
+The print the final question rule response (A) is "[full-game achievements][full-game time]Would you like to "
 
 To say full-game achievements:
 	let line break needed be false;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Schedule and Time.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Schedule and Time.i7x
@@ -822,7 +822,7 @@ Brock studies us for a moment more. Then he reaches into his pocket and pulls ou
 'Want one? They used them as packing material in my shipping box. We've got lots.'"
 
 
-The print the final question rule response (A) is "[full-game achievements][full-game time]Would you like to "
+The print the final question rule response (A) is "[full-game achievements]Would you like to "
 
 To say full-game achievements:
 	let line break needed be false;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -5,7 +5,9 @@ Use authorial modesty.
 
 Volume 8 - Tests
 
-Chapter 0 - Skipping breaks
+Chapter 0
+
+Section 1 - Skipping breaks
 
 No pauses is a truth state that varies. No pauses is initially false.
 
@@ -20,11 +22,12 @@ To custom-wait for any key:
 		wait for any key.
 
 The File of Tests is called "testing".
+The File of Automated Tests is called "autotesting".
 
-[Start automated test if File of Tests exists.]
+[Start automated test if File of Tests or File of Automated Tests exists.]
 
-A last after starting the virtual machine rule (this is the automated testing rule):
-	if the File of Tests exists:
+A last after starting the virtual machine rule (this is the no pauses rule):
+	if the File of Tests exists or the file of Automated Tests exists:
 		say "[first custom style][bracket]Test mode active. No waiting for key presses, deterministic randomness[close bracket][roman type][paragraph break]";
 		seed the random-number generator with 1234;
 		now no pauses is true;
@@ -44,6 +47,63 @@ Understand "random-seed [number]" as reseeding. Reseeding is an action out of wo
 Carry out reseeding:
 	say "[first custom style][bracket]Random-number generator seeded with [the number understood].[close bracket][roman type]";
 	seed the random-number generator with the number understood.
+
+
+Now-autotesting is a truth state that varies. Now-autotesting is initially false.
+
+Section 2 - Automated testing - Not for release
+
+A last after starting the virtual machine rule (this is the automated testing rule):
+	if the File of Automated Tests exists:
+		start the timer;
+		let test name be "[text of File of Automated Tests]";
+		say "[first custom style][bracket]Running test '[test name]'[close bracket][roman type][paragraph break]";
+		unless test name is "":
+			now now-autotesting is true;
+			call test with name test name.
+
+To call test with name (test name - some text):
+	now the reborn command is "test [test name]";
+	now sp reparse flag is true.
+
+Section 3 - Measure play time
+
+To start the timer:
+	(-
+		if (glk_gestalt(gestalt_DateTime, 0)) {
+			print "Timer started.@@10";
+			glk_current_time(gameStartTime);
+		} else {
+			print "No timer available.@@10";
+		}
+	-);
+
+Include (-
+
+Array gameStartTime --> 3;   ! microseconds elapsed since midnight on January 1, 1970, GMT/UTC
+
+Array currentTime --> 3;   ! Same as above
+
+[ readTimer;
+	glk_current_time(currentTime);
+	return (currentTime-->1 - gameStartTime-->1) * 1000 + (currentTime-->2 - gameStartTime-->2) / 1000;
+];
+
+-).
+
+To decide what number is play-time: (- readTimer() -).
+
+To show play time:
+	let current-ms be play-time;
+	let current-minutes be (current-ms / 60000) to the nearest whole number;
+	now current-ms is the remainder after dividing current-ms by 60000;
+	let current-s be (current-ms / 1000) to the nearest whole number;
+	now current-ms is the remainder after dividing current-ms by 1000;
+	say "Total play time: [current-minutes]:[current-s],[current-ms][paragraph break]";
+
+To say full-game time:
+	if now-autotesting is true:
+		show play time.
 
 
 Chapter 1 - Tests - Not for release
@@ -1127,6 +1187,5 @@ To call test:
 	special_word = NextWordStopped();
 	TestScriptSub();
 -)
-
 
 Tests ends here.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -70,7 +70,8 @@ Array autotestfilename -> $E0 'a' 'u' 't' 'o' 't' 'e' 's' 't' 'i' 'n' 'g' 0;
 	{
 		if ( glk_fileref_does_file_exist( fref ) )
 		{
-			gg_commandstr = glk_stream_open_file( fref, filemode_Read, GG_COMMANDWSTR_ROCK );
+			if ( ~~CommandStreamExists() )
+				gg_commandstr = glk_stream_open_file( fref, filemode_Read, GG_COMMANDWSTR_ROCK );
 			if ( gg_commandstr )
 			{
 				gg_command_reading = true;
@@ -86,6 +87,21 @@ Array autotestfilename -> $E0 'a' 'u' 't' 'o' 't' 'e' 's' 't' 'i' 'n' 'g' 0;
 	res = glk_fileref_does_file_exist( fref );
 	glk_fileref_destroy( fref );
 	return res;
+];
+
+[ CommandStreamExists id;
+	id = glk_stream_iterate( 0, gg_arguments );
+
+	while (id)
+	{
+		if ( gg_arguments-->0 == GG_COMMANDWSTR_ROCK )
+		{
+			gg_commandstr = id;
+			rtrue;
+		}
+		id = glk_stream_iterate( id, gg_arguments );
+	}
+	rfalse;
 ];
 
 -).

--- a/Counterfeit Monkey.materials/Extensions/Dannii Willis/Glk Object Recovery.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Dannii Willis/Glk Object Recovery.i7x
@@ -1,4 +1,4 @@
-Version 1/160919 of Glk Object Recovery (for Glulx only) by Dannii Willis begins here.
+Version 1/171025 of Glk Object Recovery (for Glulx only) by Dannii Willis begins here.
 
 "A low level utility library for managing Glk references after restarting or restoring"
 
@@ -92,10 +92,8 @@ Include (-
 	statuswin_cursize = 0;
 	gg_foregroundchan = 0;
 	gg_backgroundchan = 0;
-	#Ifdef DEBUG;
-		gg_commandstr = 0;
-		gg_command_reading = false;
-	#Endif;
+	gg_commandstr = 0;
+	gg_command_reading = false;
 	rfalse;
 ];
 -).
@@ -117,8 +115,8 @@ Include (-
 ];
 -).
 
-The identify built in windows streams rule is listed first in the glulx resetting-streams rules.
-The identify built in windows streams rule translates into I6 as "GOR_indentify_streams".
+The identify built in streams rule is listed first in the glulx resetting-streams rules.
+The identify built in streams rule translates into I6 as "GOR_indentify_streams".
 Include (-
 [ GOR_indentify_streams;
 	switch ( (+ current glulx rock +) )
@@ -127,14 +125,12 @@ Include (-
 			gg_savestr = (+ current glulx rock-ref +);
 		GG_SCRIPTSTR_ROCK:
 			gg_scriptstr = (+ current glulx rock-ref +);
-		#Ifdef DEBUG;
-			GG_COMMANDWSTR_ROCK:
-				gg_commandstr = (+ current glulx rock-ref +);
-				gg_command_reading = false;
-			GG_COMMANDRSTR_ROCK:
-				gg_commandstr = (+ current glulx rock-ref +);
-				gg_command_reading = true;
-		#Endif;
+		GG_COMMANDWSTR_ROCK:
+			gg_commandstr = (+ current glulx rock-ref +);
+			gg_command_reading = false;
+		GG_COMMANDRSTR_ROCK:
+			gg_commandstr = (+ current glulx rock-ref +);
+			gg_command_reading = true;
 	}
 	rfalse;
 ];


### PR DESCRIPTION
This is a quick-and-dirty implementation of #97. In a debug build, the game will look for a file named "autotesting.glkdata" which contains the name of an in-game test, run the test and, if it reaches the end of the game, print out the time it took.

It has some problems with the initial questions but seems to work. The autotesting file will need to have the standard header: "* //7B5A779B-4653-43DB-A516-F475DDC12987// autotesting" and then the name of the test on the next line, e.g. "me".

Note that some interpreters will not understand the ".glkdata" suffix, and instead look for a file named just "autotesting".

Any present Counterfeit Monkey-startup-data.glkdata file will break things, and should be deleted before each run.

I first tried to reuse the "testing.glkdata" file for this, but couldn't find a way to check whether a file is empty or not.

I would also be nice to be able to supply a list of actual commands rather than just the name of a pre-made internal test, but there seems to be plenty of pitfalls both when interpreting the external file and when feeding the commands to the interpreter.