### PR TITLE
New dispensers functionality

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -163,42 +163,7 @@ Instead of doing something to the sink-collectives:
 	say "I double-take before remembering to go into the women's side; it's a good thing you're nudging me along.";
 	continue the action.]
 
-A soap is a fluid thing. The indefinite article is "some". The description is "Clear fluid for washing up with."
-	The scent-description is "herbes de Provence".
-
-Does the player mean waving the letter-remover at the soap:
-	it is very likely.
-
-The soap dispenser is a closed container in the Public Convenience. It is privately-named. Understand "dispenser" or "soap dispenser" as the soap dispenser. Understand "soap" as the soap dispenser when the soap is marked invisible. It is fixed in place. The initial appearance of the soap dispenser is "A [soap dispenser] hangs beside the mirror." The description of the soap dispenser is "It's the kind where a squeeze will dispense new soap into the sink[if the soap is not in the soap dispenser]. It is also empty[end if]."
-
-Does the player mean waving the letter-remover at the soap dispenser:
-	it is very unlikely.
-
-Sanity-check taking the soap dispenser when the soap is in the soap dispenser:
-	if the subcommand of the soap dispenser matches "soap":
-		try squeezing the soap dispenser instead.
-
-Instead of squeezing the soap dispenser:
-	if soap is in the dispenser:
-		if the number of sinks in the location is greater than 0:
-			let target be a random sink in the location;
-			if a switched on tap (called target tap) is part of the target:
-				silently try switching off target tap;
-				say "First switching off [the target tap], [we][run paragraph on]";
-			otherwise:
-				if a switched on tap (called target tap) is enclosed by location:
-					say "Fortunately, the faucet below the soap dispenser is not running. ";
-				say "[We][run paragraph on]";
-			say " give the dispenser a squeeze. It deposits some soap in [the target] [--] just viscous enough not to drain away instantly.";
-			move the soap to the target;
-		otherwise:
-			say "[We] give the dispenser a squeeze and it deposits some soap on the floor, the sink having been removed from the area.";
-			move the soap to the location;
-	otherwise:
-		say "This time nothing much comes out."
-
-The soap is in the soap dispenser.
-
+Include Dispensers by Counterfeit Monkey.
 
 The wall-hole is a fixed in place container in the Public Convenience. Understand "hole" or "hole in the wall" or "hole in wall" or "wall" as the wall-hole. The printed name is "[if looking]hole[otherwise]hole in the wall[end if]". The initial appearance is "About knee-height in one of the stalls is a [wall-hole] that runs right through the wall between the men's and women's restrooms." The description of the wall-hole is "It's too small to get a good look through, really, and usually cluttered with junk."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Dispensers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Dispensers.i7x
@@ -1,0 +1,182 @@
+Dispensers by Counterfeit Monkey begins here.
+
+Use authorial modesty.
+
+A soap is a fluid thing. The indefinite article is "some". The description is "Clear fluid for washing up with."
+	The scent-description is "herbes de Provence".
+
+Does the player mean waving the letter-remover at the soap:
+	it is very likely.
+
+Does the player mean waving the letter-remover at the soap dispenser:
+	it is very unlikely.
+
+Does the player mean waving the letter-remover at the sap-dispenser:
+	it is very unlikely.
+
+Does the player mean waving the letter-remover at the sop-dispenser:
+	it is very unlikely.
+
+Does the player mean waving the letter-remover at the sap-liquid:
+	it is very likely.
+
+Does the player mean waving the letter-remover at the sop:
+	it is very likely.
+
+The soap dispenser is a closed container in the Public Convenience. It is privately-named. Understand "dispenser" or "soap dispenser" as the soap dispenser. Understand "soap" as the soap dispenser when the soap is marked invisible. It is fixed in place. The initial appearance of the soap dispenser is "A [soap dispenser] hangs beside the mirror." The description of the soap dispenser is "It's the kind where a squeeze will dispense new soap into the sink[if the soap is not in the soap dispenser]. It is also empty[end if]."
+
+Sanity-check taking the soap dispenser when the soap is in the soap dispenser:
+	if the subcommand of the soap dispenser matches "soap":
+		try squeezing the soap dispenser instead.
+
+Sanity-check taking the sap-dispenser when the sap-liquid is in the sap-dispenser:
+	if the subcommand of the sap-dispenser matches "sap":
+		try squeezing the sap-dispenser instead.
+
+Sanity-check taking the sop-dispenser when the sop is in the sop-dispenser:
+	if the subcommand of the sop-dispenser matches "sop":
+		try squeezing the sop-dispenser instead.
+
+Instead of squeezing something dispenser-like (called dispenser-thing):
+	let soap-like be a content corresponding to a source of dispenser-thing in the Table of Dispensers;
+	if soap-like is in the dispenser-thing:
+		let target be a random sink in the location;
+		if the soap-sap-receptacle-supporter is non-empty:
+			now target is the first thing held by soap-sap-receptacle-supporter;
+		if target is a sink:
+			if a switched on tap (called target tap) is part of the target:
+				silently try switching off target tap;
+				say "First switching off [the target tap], [we][run paragraph on]";
+			otherwise:
+				if a switched on tap (called target tap) is enclosed by location:
+					say "Fortunately, the faucet below [the dispenser-thing] is not running. ";
+			say "We give the dispenser a squeeze. It deposits [a soap-like] in [the target][unless soap-like is a sop] [--] just viscous enough not to drain away instantly[end if].";
+		otherwise:
+			if target is nothing:
+				say "We give the dispenser a squeeze and it deposits [a soap-like] on the floor, the sink having been removed from the area.";
+				now target is the location;
+			otherwise:
+				say "We give the dispenser a squeeze. It deposits [a soap-like] in [the target].";
+		move the soap-like to the target;
+	otherwise:
+		say "This time nothing much comes out."
+
+Table of Dispensers
+source (a thing)	content (a thing)
+soap dispenser	soap
+sap-dispenser	sap-liquid
+sop-dispenser	sop
+
+The soap is in the soap dispenser.
+
+The soap-sap-receptacle-supporter is a scenery supporter in the public convenience. The printed name of the soap-sap-receptacle-supporter is "[floor-or-sink]".
+
+Under-dispenser-putting is an action applying to two things.
+
+Understand "put [something] under/below [a dispenser-like thing]" as under-dispenser-putting.
+
+Carry out under-dispenser-putting:
+	try putting the noun on the soap-sap-receptacle-supporter instead.
+
+Every turn when the location is the Public Convenience and the soap-sap-receptacle-supporter is not part of a sink and the soap-sap-receptacle-supporter is empty and there is a sink in location (this is the attach soap-sap-receptacle-supporter to a sink rule):
+	now the soap-sap-receptacle-supporter is part of a random sink in location.
+
+A dangerous destruction rule for a sink which incorporates the soap-sap-receptacle-supporter:
+	if the soap-sap-receptacle-supporter is not empty:
+		let item be the first thing held by soap-sap-receptacle-supporter;
+		say "[The item] [fall] to the floor, landing under the [soap-or-sap-dispenser].";
+	move soap-sap-receptacle-supporter to Public Convenience;
+
+Carry out waving the letter-remover at the soap dispenser creating the sap-dispenser when the soap is in the soap dispenser:
+	if the sap-liquid is in the repository:
+		move the sap-liquid to the sap-dispenser;
+		now the sap-liquid is proffered by nothing;
+		now the sap-liquid is proffered by the soap;
+	move the soap to the repository.
+
+Carry out  waving the letter-remover at the soap dispenser creating the sop-dispenser when the soap is in the soap dispenser:
+	if the sop is in the repository:
+		move the sop to the sop-dispenser;
+		now the sop is proffered by nothing;
+		now the sop is proffered by the soap;
+	move the soap to the repository.
+
+Carry out  putting the gel on the sap-dispenser when the sap-liquid is in the sap-dispenser:
+	if the soap is in the repository:
+		move the soap to the soap dispenser;
+	move the sap-liquid to the repository.
+
+Carry out  putting the gel on the sop-dispenser when the sop is in the sop-dispenser:
+	if the soap is in the repository:
+		move the soap to the soap dispenser;
+	move the sop to the repository.
+
+To say soap-or-sap-dispenser:
+	if the soap dispenser is in the Public Convenience:
+		say "soap dispenser";
+	otherwise:
+		if the sap-dispenser is in the Public Convenience:
+			say "sap dispenser";
+		otherwise:
+			say "sop dispenser".
+
+To say floor-or-sink:
+	if the soap-sap-receptacle-supporter is part of a sink:
+		say "sink";
+	otherwise:
+		say "floor".
+
+Instead of inserting a container into a sink when the location is Public Convenience:
+	try putting the noun on the soap-sap-receptacle-supporter.
+
+Instead of putting a container on a sink when the location is Public Convenience:
+	try putting the noun on the soap-sap-receptacle-supporter.
+
+Check putting something on the soap-sap-receptacle-supporter when the soap-sap-receptacle-supporter is non-empty:
+	let item be the first thing held by soap-sap-receptacle-supporter;
+	silently try taking the item;
+	if the player carries the item:
+		say "We remove [the item] from under the [soap-or-sap-dispenser].";
+	otherwise:
+		say "[The item] [are] already under the [soap-or-sap-dispenser]. There is no more room there." instead.
+
+Report putting something on the soap-sap-receptacle-supporter:
+	say "We place [the noun] on the [floor-or-sink], right below the [soap-or-sap-dispenser]." instead.
+
+Rule for writing a paragraph about something on the soap-sap-receptacle-supporter:
+	say "[The item described] [sit] on the [floor-or-sink], right under the [soap-or-sap-dispenser]."
+
+Definition: a thing is dispenser-like:
+	if it is the soap dispenser:
+		yes;
+	if it is the sap-dispenser:
+		yes;
+	if it is the sop-dispenser:
+		yes;
+	no.
+
+Instead of emptying the soap into something:
+	if the the soap is in location:
+		try taking the soap instead;
+	otherwise:
+		say "The soap sticks to the bottom of [the holder of the soap]."
+
+Instead of emptying the sap-liquid into something:
+	if the the sap-liquid is in location:
+		try taking the sap-liquid instead;
+	otherwise:
+		say "The sap sticks to the bottom of [the holder of the sap-liquid]."
+
+Instead of filling something with the sap-liquid:
+	if the the sap-liquid is in location:
+		try taking the sap-liquid;
+	otherwise:
+		say "The sap sticks to the bottom of [the holder of the sap-liquid]."
+
+Instead of filling something with the soap:
+	if the the soap is in location:
+		try taking the soap;
+	otherwise:
+		say "The soap sticks to the bottom of [the holder of the soap]."
+
+Dispensers ends here.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Fakes.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Fakes.i7x
@@ -531,6 +531,7 @@ The snap is fake. [I1876_snap]
 The sock is fake. [I2220_sock]
 The sod is fake. [I2226_sod]
 The sop is fake. [I2187_sop]
+The sop-dispenser is fake.
 The sord is fake. [I2225_sord]
 The sot is fake. [I2288_sot]
 The spa is fake. [I1884_spa]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Homonym Indices.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Homonym Indices.i7x
@@ -1279,5 +1279,7 @@ An ignition has homonym index 1275.
 A tap has homonym index 1276.
 A bath has homonym index 1277.
 Yourself has homonym index 1278.
+The soap-sap-receptacle-supporter has homonym index 1286.
+The sop-dispenser has homonym index 1287.
 
 Homonym Indices ends here.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Initial Proffering.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Initial Proffering.i7x
@@ -938,11 +938,13 @@ The small tables proffers the small tables. [I789_small_tables]
 The smell proffers The smell.
 The snap proffers the snap. [I1876_snap]
 The soap dispenser proffers the soap dispenser. [I997_soap_dispenser]
+The soap-sap-receptacle-supporter proffers the soap-sap-receptacle-supporter.
 The soap proffers the soap. [I996_soap]
 The sock proffers the sock. [I2220_sock]
 The sod proffers the sod. [I2226_sod]
 The soil proffers the soil. [I641_soil]
 The sop proffers the sop. [I2187_sop]
+The sop-dispenser proffers the sop-dispenser. [I2187_sop]
 The sord proffers the sord. [I2225_sord]
 The sot proffers the sot. [I2288_sot]
 The souvenir tea-towels proffers the souvenir tea-towels. [I596_souvenir_tea_towels]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Letter Hash Codes.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Letter Hash Codes.i7x
@@ -1167,10 +1167,12 @@ The smell has hash code 268304.
 The snap has hash code 303105. [I1876_snap]
 The soap dispenser has hash code 450841. [I997_soap_dispenser]
 The soap has hash code 311297. [I996_soap]
+The soap-sap-receptacle-supporter has hash code 149536.
 The sock has hash code 279556. [I2220_sock]
 The sod has hash code 278536. [I2226_sod]
 The soil has hash code 280832. [I641_soil]
 The sop has hash code 311296. [I2187_sop]
+The sop-dispenser has hash code 450840. [I2187_sop]
 The sord has hash code 409608. [I2225_sord]
 The sot has hash code 802816. [I2288_sot]
 The souvenir tea-towels has hash code 8284433. [I596_souvenir_tea_towels]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Liquids.i7x
@@ -14,6 +14,10 @@ Instead of waving or squeezing or pulling or pushing or rubbing or turning an un
 	say "[The noun] [don't] really respond to that kind of manipulation."
 
 Instead of taking an uncontained fluid thing (called the fluid):
+	if the fluid is the sap-liquid or the fluid is the soap:
+		if the fluid is in a container (called receptacle):
+			say "[The fluid] is too fluid and sticky to pick up easily.";
+			stop the action;
 	say "[The fluid] [are] not the kind of thing [we] can just pick up and carry away."
 
 Understand "drink from [something]" as drinking.
@@ -82,10 +86,10 @@ Understand "fill [a container] with [something]" as filling it with.
 Understand "fill [something] with [a fluid thing]" as filling it with.
 Understand "fill [something] with [something]" as filling it with.
 
-Understand "pour [something] in/into [something]" as filling it with (with nouns reversed).
-Understand "pour [a fluid thing] in/into [something]" as filling it with (with nouns reversed).
-Understand "pour [something] in/into [a container]" as filling it with (with nouns reversed).
-Understand "pour [a fluid thing] in/into [a container]" as filling it with (with nouns reversed).
+Understand "empty [something] in/into [something]" as filling it with (with nouns reversed).
+Understand "empty [a fluid thing] in/into [something]" as filling it with (with nouns reversed).
+Understand "empty [something] in/into [a container]" as filling it with (with nouns reversed).
+Understand "empty [a fluid thing] in/into [a container]" as filling it with (with nouns reversed).
 
 [ Every turn when a fluid thing (called target) is in a pan:
 	unless the target is contained:
@@ -104,12 +108,13 @@ Check inserting something into a fluid thing (called the liquid):
 		say "[We] don't want to get [second noun] all over [the noun]." instead.
 
 Check putting an uncontained fluid thing (called the liquid) on something:
-	if the liquid is washing-appropriate:
-		try washing the second noun instead;
-	if the second noun is a drain (called D):
-		say "[The liquid] would disappear down [the D]." instead;
-	otherwise:
-		say "[We] don't want [noun] all over [the second noun]." instead.
+	unless the second noun is the spinner or the second noun is the programmable dais:
+		if the liquid is washing-appropriate:
+			try washing the second noun instead;
+		if the second noun is a drain (called D):
+			say "[The liquid] would disappear down [the D]." instead;
+		otherwise:
+			say "[We] don't want [noun] all over [the second noun]." instead.
 
 Check putting a fluid thing on a fluid thing:
 	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
@@ -118,7 +123,7 @@ Check inserting a fluid thing into a fluid thing:
 	say "There's no restoration gel that will separate mixed liquids, you know. I'd rather stay away from the chemistry experiments." instead.
 
 Sanity-check inserting an uncontained fluid thing into a container (called target):
-	unless the target is a pan:
+	unless the target is a pan or the target is the synthesizer or the target is the t-inserter or the target is the cryptolock:
 		try filling the second noun with the noun instead.
 
 Instead of inserting the funnel into a container which incorporates a drain:
@@ -156,6 +161,7 @@ Check filling it with:
 
 
 Understand "empty [something]" as emptying. Emptying is an action applying to one thing.
+Understand the command "pour" as "empty".
 
 Carry out emptying:
 	if the noun is not a supporter and the noun is not a container:
@@ -182,7 +188,11 @@ Carry out emptying it into:
 	if the noun is empty:
 		say "[The noun] [are] empty already." instead;
 	if the noun is fluid-filled:
-		say "I'd rather leave [the first thing held by the noun] where [they] [are]." instead;
+		let contents be the first thing held by the noun;
+		if the contents is the soap or the contents is the sap-liquid:
+			say "[The contents] sticks to the bottom of [the noun]." instead;
+		otherwise:
+			say "I'd rather leave [the contents] where [they] [are]." instead;
 	say "[first custom style][bracket]Try to TAKE things from [the noun] and then PUT them [in-on the second noun] instead.[close bracket][roman type][line break]".
 
 Check an actor washing (this is the new restrict washing to the proximity of sinks rule):

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -2934,9 +2934,9 @@ The description of the saltcat is "It's a mixture of salt, lime, and meal, used 
 
 The description of a sap is "A slack-faced fellow, eager to believe what he's told. The grin he's giving us right now is usually found only on golden retrievers."
 
-The sap-dispenser is a closed transparent container. The printed name is "sap dispenser". Understand "sap dispenser" or "dispenser" as the sap-dispenser. It is scenery. The initial appearance of the sap-dispenser is "A sap dispenser hangs beside the mirror." The description of the sap-dispenser is "It's the kind where a squeeze will dispense sap into the sink[if the sap-liquid is not in the sap-dispenser]. It is also empty[end if]."
+The sap-dispenser is a closed container. The printed name is "sap dispenser". Understand "sap dispenser" or "dispenser" as the sap-dispenser. Understand "sap" as the sap-dispenser when the sap-liquid is marked invisible. It is fixed in place. The initial appearance of the sap-dispenser is "A sap dispenser hangs beside the mirror." The description of the sap-dispenser is "It's the kind where a squeeze will dispense sap into the sink[if the sap-liquid is not in the sap-dispenser]. It is also empty[end if]."
 
-A sap-liquid is a fluid thing. The indefinite article is "some". The scent-description is "pine resin". The printed name is "sap". Understand "sap" as the sap-liquid. The description is "Sticky and yellow-col[our]ed goo from a tree, rather than 'sap' as in a person. But considering it comes from a sap dispenser, that was probably inevitable."
+A sap-liquid is a fluid thing. The indefinite article is "some". The scent-description is "pine resin". The printed name is "sap". Understand "sap" as the sap-liquid. The description is "Sticky and yellow-col[our]ed goo from a tree, rather than 'sap' as in a person. But considering it comes from a dispenser, that was probably inevitable."
 
 Sanity-check touching the sap-liquid:
 	say "It would be sticky and be hard to get off." instead.
@@ -2944,8 +2944,7 @@ Sanity-check touching the sap-liquid:
 Sanity-check burning the sap-liquid:
 	say "I think some resins might burn when dry, but I'm not sure that applies here, and in any case it wouldn't help." instead.
 
-Instead of squeezing the sap-dispenser:
-	say "Nothing much comes out."
+The sop-dispenser is a closed container. The printed name is "sop dispenser". Understand "sop dispenser" or "dispenser" as the sop-dispenser. Understand "sop" as the sop-dispenser when the sop is marked invisible. It is fixed in place. The initial appearance of the sop-dispenser is "A sop dispenser hangs beside the mirror." The description of the sop-dispenser is "It's the kind where a squeeze will dispense a sop into the sink[if the sop is not in the sop-dispenser]. It is also empty[end if]."
 
 The satin-pin is wearable. The printed name of the satin-pin is "satin pin". Understand "satin" or "satin pin" as the satin-pin. Understand "pin" as the satin-pin when the pin is marked invisible. The description of the satin-pin is "It's a little brooch, probably not very valuable, bearing a blue and white satin rosette. The edges of the rosette have yellowed with age, and there is a blob of glue at the center that must once have held some additional decoration."
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Major Contents.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Major Contents.i7x
@@ -718,14 +718,14 @@ The repository contains a mall figurine.
 
 [soap]
 
-The repository contains a sap, a sop,
+The repository contains a sap, a sap-liquid, a sop,
 	a stop, [t-insert derivatives]
 	a top-toy, [derive insertions]
 	some pas, some pots, a spot, a pot, an alterna-pot. [anagram all]
 
 [soap-dispenser]
 
-The repository contains a sap-dispenser.
+The repository contains a sap-dispenser and a sop-dispenser.
 
 [soil]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -326,7 +326,7 @@ Check waving the letter-remover at something which is enclosed by the player:
 		try taking off the second noun;
 		if the player does not carry the second noun:
 			say "Altering one's clothes while they're on can have some unfortunate side effects." instead;
-	if the player does not carry the second noun:
+	if the player does not carry the second noun and the second noun is not an uncontained fluid:
 		try taking the second noun;
 		if the player does not carry the second noun:
 			let enclosure be the holder of the second noun;


### PR DESCRIPTION
This makes the sap dispenser actually contain sap, which can be gelled back into soap. It also adds a sop dispenser, containing a sop, which likewise can be gelled back into soap. Furthermore, it restores the possibility to place a container on the sink (or the floor if no sink is available) in order to collect the liquid coming out of the dispenser. Includes some fixes to fluid handling.