### PR TITLE
Responses to trying to use the trap

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -6310,6 +6310,18 @@ Portcullis-threat ends in freedom when the location is Precarious Perch.
 
 When Portcullis-threat begins:
 	say "Someone is coming into the workshop upstairs. There's at most a few seconds before they'll be down the tunnel.";
+	if there is an open trap in Oracle Project:
+		the trap is discovered in 1 turn from now;
+	if there is an open trap in the surveillance room:
+		the trap is discovered in 2 turns from now;
+	if there is an open trap in the tunnel through chalk:
+		the trap is discovered in 3 turns from now.
+
+At the time when the trap is discovered:
+	let N be "[the holder of the trap]";
+	let N be N in lower case;
+	now the trap is closed;
+	say "'What's this?' [we] hear somebody say from the general direction of [N]. Then there is a loud snap. We flinch, but there is no blood-curling scream. 'We're lucky nobody stepped into that' a male voice says, followed by some brief relieved laughter."
 
 Check going to the Tunnel from Personal Apartment when Portcullis-threat is happening:
 	say "[We] run straight into the guards. [We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
@@ -6325,7 +6337,7 @@ Instead of going to Private Solarium from Personal Apartment when Portcullis-thr
 		say "The guards are coming down the tunnel right now. [We] should find a way to delay them."
 
 When Portcullis-threat ends in capture:
-	say "The guards arrive. [We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
+	say "The guards arrive. [if there is an open trap in location]The first one to enter deftly stops before the trap, and then proceeds to spring it with her rifle. [end if][We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
 	end the story saying "That could have gone better"
 
 When Portcullis-threat ends in delay:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -6315,7 +6315,7 @@ At the time when the trap is discovered:
 	let N be "[the holder of the trap]";
 	let N be N in lower case;
 	now the trap is closed;
-	say "'What's this?' [we] hear somebody say from the general direction of [N]. Then there is a loud snap. We flinch, but there is no blood-curling scream. 'We're lucky nobody stepped into that' a male voice says, followed by some brief relieved laughter."
+	say "'What's this?' [we] hear a faint voice say from the general direction of [N]. Then there is a loud snap. We flinch, but the blood-curling scream never comes. 'Good thing nobody stepped into that' another voice says, followed by some nervous laughter."
 
 Check going to the Tunnel from Personal Apartment when Portcullis-threat is happening:
 	say "[We] run straight into the guards. [We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
@@ -6331,7 +6331,7 @@ Instead of going to Private Solarium from Personal Apartment when Portcullis-thr
 		say "The guards are coming down the tunnel right now. [We] should find a way to delay them."
 
 When Portcullis-threat ends in capture:
-	say "The guards arrive. [if there is an open trap in location]The first one to enter deftly stops before the trap, and then proceeds to spring it with her rifle. [end if][We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
+	say "The guards arrive. [if there is an open trap in location]The first to enter stops just as she is about to step into the trap, and then proceeds to spring it with her rifle. [end if][We] [are] captured and taken away for interrogation, and it's some time before Atlantida is able to arrange for our release.";
 	end the story saying "That could have gone better"
 
 When Portcullis-threat ends in delay:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -5993,13 +5993,7 @@ that the outside world matters is an unlisted informative quip.
 	It quip-supplies Atlantida-woman.
 
 Availability rule for that the outside world matters:
-	if Atlantida-woman recollects thing-about-democracy:
-		make no decision;
-	otherwise:
-		it is off-limits.
-
-Availability rule for how she justifies cold storage:
-	if Atlantida-woman recollects thing-about-democracy:
+	if Atlantida-woman recollects gel-shot:
 		make no decision;
 	otherwise:
 		it is off-limits.
@@ -6208,11 +6202,11 @@ We say nothing.";
 Table of Ultratests (continued)
 topic	stuff	setting
 "almostlast"	{ anagramming gun, bullets, tub, counterweight }	The Tunnel
-"lastmeeting"	{ anagramming gun, tub }	Personal Apartment
+"lastmeeting"	{ anagramming gun, bullets, tub }	Personal Apartment
 
-Test almostlast with "tutorial off / load gun / put counterweight on hook / open tub / open portcullis / go through portcullis / x files / a cold storage / look / shoot anagramming gun at gel rifle / look / gel astrologer / shoot gel rifle at atlantida" [in the Tunnel  holding the anagramming gun and the bullets and the tub and the counterweight.]
+Test almostlast with "tutorial off / establish / unlegend / load gun / put counterweight on hook / open tub / open portcullis / go through portcullis / x files / z / a cold storage / look / shoot anagramming gun at gel rifle / look / gel astrologer / shoot gel rifle at atlantida" [in the Tunnel  holding the anagramming gun and the bullets and the tub and the counterweight.]
 
-Test lastmeeting with "tutorial off / open tub / x files / a cold storage / look / shoot anagramming gun at gel rifle / look / gel astrologer / shoot gel rifle at atlantida" [in the Personal Apartment holding the anagramming gun and the tub.]
+Test lastmeeting with "tutorial off / establish / unlegend / load gun / open tub / x files / a cold storage / look / shoot anagramming gun at gel rifle / look / gel astrologer / shoot gel rifle at atlantida" [in the Personal Apartment holding the anagramming gun and the tub.]
 
 Section 14 - The Nicer Atlantida
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -4001,11 +4001,20 @@ Understand "set [trap]" as opening.
 Sanity-check opening the trap:
 	if the trap is open:
 		make no decision;
-	if the trap is not in the location:
-		say "It would be difficult, not to mention unsafe, to try to set the trap when it's anywhere but on the [ground]." instead.
+	if the trap is not in location:
+		say "It would be difficult, not to mention unsafe, to try to set the trap when it's anywhere but on the [ground]." instead;
+	if Boar Attack is happening:
+		say "[one of][We] briefly struggle to get the trap open, but the boar goes straight for [us] and [we] have to run in order to avoid it[or][We] [are] not going to try that again[stopping]." instead;
+	if the location is nautical:
+		say "In this cramped space, one of our friends is likely to step into the trap, if [we] don't do it [ourselves]." instead.
 
 Report opening the trap:
-	say "[We] apply a great deal of pressure to the levers of the trap and finally manage to get the jaws open." instead.
+	say "[We] apply a great deal of pressure to the levers of the trap and finally manage to get the jaws open";
+	if Atlantida-woman is in location:
+		say ".[paragraph break]'Did you really expect me to walk into that?' Atlantida asks, eyebrows raised." instead;
+	if further guards is happening or guard-imminence is happening or portcullis-threat is happening:
+		say ". [We] shudder to think of the consequences should somebody step into it";
+	say "." instead.
 
 Sanity-check taking the open trap:
 	say "[We] don't want to get our hand anywhere near the trap while it's still set to spring." instead.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Repository Alphabetic Details.i7x
@@ -4004,16 +4004,18 @@ Sanity-check opening the trap:
 	if the trap is not in location:
 		say "It would be difficult, not to mention unsafe, to try to set the trap when it's anywhere but on the [ground]." instead;
 	if Boar Attack is happening:
-		say "[one of][We] briefly struggle to get the trap open, but the boar goes straight for [us] and [we] have to run in order to avoid it[or][We] [are] not going to try that again[stopping]." instead;
+		say "[one of][We] briefly struggle to get the trap open, but the boar goes straight for [us] and [we] have to run[or][We] [are] not going to try that again[stopping]." instead;
 	if the location is nautical:
-		say "In this cramped space, one of our friends is likely to step into the trap, if [we] don't do it [ourselves]." instead.
+		say "In this cramped space, one of our friends is going to step on the trap, if [we] don't do it first." instead.
 
 Report opening the trap:
 	say "[We] apply a great deal of pressure to the levers of the trap and finally manage to get the jaws open";
 	if Atlantida-woman is in location:
-		say ".[paragraph break]'Did you really expect me to walk into that?' Atlantida asks, eyebrows raised." instead;
-	if further guards is happening or guard-imminence is happening or portcullis-threat is happening:
-		say ". [We] shudder to think of the consequences should somebody step into it";
+		say ".[paragraph break]'Did you really expect me to walk into that?' Atlantida asks, with genuine surprise in her voice." instead;
+	if further guards is happening or guard-imminence is happening or portcullis-threat is happening or atlantida-refreshed is in location:
+		say ". I really don't want to think about what will happen if somebody steps on it";
+	if atlantida-refreshed is in location:
+		say ".[paragraph break]'That seems brutal,' Atlantida remarks";
 	say "." instead.
 
 Sanity-check taking the open trap:
@@ -4059,6 +4061,12 @@ Report springing the trap with something:
 
 Sanity-check attacking the trap with something:
 	try springing the trap with the second noun instead.
+
+Understand "step into/in [thing]" as entering.
+Understand "step on [thing]" as standing up on.
+
+Instead of standing up on the trap:
+	try entering the trap.
 
 Instead of entering the open trap:
 	say "Even you don't have the self-control [--] or the suicidal inclination [--] necessary to break your own leg with forty pounds worth of cold iron bear trap."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tests.i7x
@@ -346,7 +346,6 @@ Carry out animal-summoning:
 Report animal-summoning:
 	try looking.
 
-
 [Since it takes several steps to get a working car, sometimes we want to be able to test without going through that rigamarole.]
 
 Understand "car-acquire" as car-acquiring. Car-acquiring is an action out of world.


### PR DESCRIPTION
The trap is actually not useful for anything, but the player might try to use it to stop Atlantida, the guards or the boar. This PR adds some responses to this.