### PR TITLE
Allow fixing a second car

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
@@ -70,7 +70,12 @@ A ranking rule when aquarium-exterior is not as-yet-unknown and Aquarium is visi
 	increase description-rank of the target by 20.
 
 Rule for writing a topic sentence about a car (called target car) when the location is Deep Street and Aquarium is visited and aquarium-exterior is not as-yet-unknown and aquarium-exterior is mentionable:
-	say "Our pathetic little [target car] is parked right outside [the aquarium-exterior]. "
+	let N be the number of cars in location;
+	if N is greater than 1:
+		say "Our pathetic little cars are parked right outside [the aquarium-exterior]. ";
+		now every car in location is mentioned;
+	otherwise:
+		say "Our pathetic little [target car] is parked right outside [the aquarium-exterior]. "
 
 Instead of searching aquarium-exterior:
 	if the aquarium-closed-sign is marked-visible:

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -764,6 +764,7 @@ Table of Ultratests (continued)
 topic	stuff	setting
 "mechanicbug"	{ tub, funnel, foil, chard }	high street
 "mech2"	{ tub, funnel, foil, chard }	high street
+"two-cars"	{ gas, soil }	high street
 
 Test mechanicbug with "tutorial off / wave b-remover at garbage / test car-series / wave h-remover at chard / wave d-remover at card / test car-series / open tub / gel car / wave f-remover at foil / test car-series / wave d-remover at chard / wave h-remover at char / test car-series / wave n-remover at funnel / test car-series / put fuel in car / test car-series" [holding the tub and the funnel and the foil and the chard in high street.]
 
@@ -771,6 +772,14 @@ Test mechanicbug with "tutorial off / wave b-remover at garbage / test car-serie
 Test mech2 with "tutorial off / wave b-remover at garbage / test car-series / wave h-remover at chard / wave d-remover at card / test car-series / open tub / gel car / wave n-remover at funnel / test car-series / wave d-remover at chard / wave h-remover at char / test car-series / put fuel in car / test car-series / wave f-remover at foil / test car-series" [holding the tub and the funnel and the foil and the chard in high street.]
 
 Test car-series with "ask mechanic to fix car / show fuel to mechanic / ask mechanic about fuel / show gas to mechanic / ask mechanic about gas / show oil to mechanic / ask mechanic about oil / ask mechanic about car / show car to mechanic / get in car / start car / switch on car / switch on ignition / get out".
+
+Test two-cars with "tutorial off / car-acquire / purloin chair / wave s-remover at soil / wave i-remover at chair / wave h-remover at char / test mechanicbug".
+
+Does the player mean showing a damaged car to the mechanic:
+	it is very likely.
+
+Does the player mean showing an unfueled car to the mechanic:
+	it is very likely.
 
 Instead of showing an operational car to the mechanic:
 	say "We signify the car by pointing.";
@@ -789,7 +798,7 @@ whether car be fixed is a questioning quip.
 	The true-name is "whether car be fixed".
 	Understand "is" as whether car be fixed.
 	The comment is "'Is the car fixed now?' we ask."
-	The reply is "'The oil is in,' the mechanic says[if at least one car is fueled]. 'Should run all right[otherwise]. 'Might be it's out of fuel, though[end if].'".
+	The reply is "'The oil is in,' the mechanic says[unless there is an unfueled car in location]. 'Should run all right[otherwise]. 'Might be it's out of fuel, though[end if].'".
 	It quip-supplies the mechanic.
 	It is repeatable.
 	[Every car is mentioned by whether car be fixed.]
@@ -799,10 +808,10 @@ Instead of showing a damaged car to the mechanic:
 	say "We indicate the car with gestures.";
 	try the mechanic discussing why the car does not run.
 
-Instead of asking the mechanic to try doing something when a car is the noun or a car is the second noun:
+Instead of asking the mechanic to try doing something when the noun is a car or the second noun is a car:
 	if the noun is an oil or the second noun is an oil:
 		try discussing whether the oil will work;
-	otherwise if no car is operational:
+	otherwise if no car is operational or a damaged car is in location:
 		try discussing why the car does not run;
 	otherwise:
 		say "The mechanic just looks confused."
@@ -843,7 +852,7 @@ Carry out the mechanic discussing why the car does not run:
 	assign "Get oil for the mechanic".
 
 Instead of showing an oil to the mechanic:
-	if at least one car is operational:
+	if at least one car is operational and there is no damaged car in location:
 		continue the action;
 	otherwise:
 		try giving the noun to the mechanic.
@@ -851,14 +860,14 @@ Instead of showing an oil to the mechanic:
 Instead of giving an oil to the mechanic when there is no car in location:
 	try discussing check out this oil-1.
 
-Instead of giving an oil to the mechanic when at least one car is operational:
+Instead of giving an oil to the mechanic when at least one car is operational and there is no damaged car in location:
 	try discussing check out this oil.
 
 Carry out the mechanic discussing whether the oil will work:
 	complete "Get oil for the mechanic";
 	record "repairing our car" as achieved.
 
-whether the oil will work is an unlisted offering quip.
+whether the oil will work is a repeatable unlisted offering quip.
 	The comment is "'Will this work?' [We] hold out the oil."
 	The reply is "[thank-mechanic]'Should do,' he says. Rolling up his sleeves, he goes to work on the car. There is no small amount of banging and muttering, but finally he stands back and announces that he believes it is now in working condition."
 	It indirectly-follows why the car does not run.
@@ -877,7 +886,7 @@ check out this oil-1 is an unlisted repeatable demonstration quip.
 	[Every oil is mentioned by check out this oil-1.]
 
 Availability rule for check out this oil:
-	if the player encloses an oil and at least one car is operational:
+	if the player encloses an oil and at least one car is operational and there is no damaged car in location:
 		make no decision;
 	it is off-limits.
 
@@ -960,7 +969,7 @@ An availability rule for whether the oil will work:
 Carry out the mechanic discussing whether the oil will work:
 	let chosen-oil be a random oil enclosed by the player;
 	now the chosen-oil is nowhere;
-	let target be a random car in location;
+	let target be a random damaged car in location;
 	now the target is operational.
 
 thank the mechanic is a thanking quip. It assumes thank-mechanic.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -896,6 +896,17 @@ check out this oil is an unlisted repeatable demonstration quip.
 	It quip-supplies the mechanic.
 	[Every oil is mentioned by check out this oil.]
 
+Instead of giving the poppy-oil to the mechanic:
+	try showing the poppy-oil to the mechanic.
+
+Instead of showing the poppy-oil to the mechanic:
+	say "[demonstration of the poppy-oil][paragraph break]";
+	if there is a damaged car in location:
+		say "'[one of]That's the wrong kind of oil[or]That is not the kind of oil we need[at random][no line break]";
+	otherwise:
+		say "'[one of]I know nothing about that kind of oil[or]I have no use for that[or]That is not the kind of oil I have use for[at random][no line break]";
+	say ",' he [one of]says[or]remarks[or]shrugs[at random]."
+
 An availability rule for where oil might be:
 	if an oil is seen:
 		it is off-limits;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -349,6 +349,16 @@ Check waving the letter-remover at something creating a person when the letter-r
 Check waving the letter-remover at something creating an r-abstract thing when the letter-remover device is not upgraded:
 	say "[The second noun] flickers and there is a brief image of [a generated object] in [regarding the second noun][their] place [--] the concept strangely embodied in a physical form [--] before the power gives out[one of]. I guess your device there just isn't tuned to reify abstracts[stopping]." instead;
 
+Check waving the letter-remover at something creating a car:
+	if the second noun is enclosed by a container (called outer):
+		unless the outer is the garage:
+			say "It is probably not a good idea to create a car inside [the outer]. Perhaps [we] should put [the second noun] somewhere safer first." instead.
+
+Check putting gel on something which is proffered by a car:
+	if the second noun is enclosed by a container (called outer):
+		unless the outer is the garage:
+			say "It is probably not a good idea to create a car inside [the outer]. Perhaps [we] should put [the second noun] somewhere safer first." instead.
+
 Check waving the letter-remover device at something (this is the checking for danger rule):
 	abide by the dangerous destruction rules for the second noun;
 	[abide by the dangerous construction rules for the generated object.]

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Tools.i7x
@@ -351,12 +351,12 @@ Check waving the letter-remover at something creating an r-abstract thing when t
 
 Check waving the letter-remover at something creating a car:
 	if the second noun is enclosed by a container (called outer):
-		unless the outer is the garage:
+		unless the outer is the garage or the outer is the synthesizer:
 			say "It is probably not a good idea to create a car inside [the outer]. Perhaps [we] should put [the second noun] somewhere safer first." instead.
 
 Check putting gel on something which is proffered by a car:
 	if the second noun is enclosed by a container (called outer):
-		unless the outer is the garage:
+		unless the outer is the garage or the outer is the synthesizer:
 			say "It is probably not a good idea to create a car inside [the outer]. Perhaps [we] should put [the second noun] somewhere safer first." instead.
 
 Check waving the letter-remover device at something (this is the checking for danger rule):

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -1068,7 +1068,7 @@ Instead of going from a road to a road:
 		continue the action;
 	if a car (called target) is in location:
 		if more than one car is in location:
-			now the target is a random fueled car in location;
+			now the target is a random fueled operational car in location;
 			if target is nothing:
 				now the target is a random car in location;
 		try entering the target;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -1110,13 +1110,24 @@ Understand "honk" or "honk at [text]" as a mistake ("[if the player is not in a 
 
 Understand "protest" or "join protest" or "picket" as a mistake ("If I thought you could change Atlantis that way, I'd be on board. But I've given up on social action long since.").
 
-A car is a kind of vehicle. A car is usually transparent. The heft of a car is 7. The flexible appearance of a car is "Our car[one of] [--] a sub-sub-compact that looks like it might be outraced by a kid on a scooter [--][or] [--] which might better be described as a covered bicycle [--][or][at random] is parked [if the location is offroad]illegally [end if]nearby."
+A car is a kind of vehicle. A car is usually transparent. The heft of a car is 7. The flexible appearance of a car is "".
 	The description of a car is "It is little larger than a toy, but that is what you want when driving on the streets around here. Any substantial vehicle wouldn't fit down the winding drives."
 	The introduction is "Here is how my mother gets around. She takes a 300 Euro Hermès scarf with an orange border and a pattern of prancing horses. She tosses it in the air. As it falls, she shoots it twice, like a clay pigeon: once to take out the F, the second time for the S. And such a car: buttery leather seats, jaguar lines. If someone asks how she gets such good results, she jokes that it's because of her quality materials.
 
 Suffice it to say that we are not similarly blessed."
 	Understand "toy" or "sub-subcompact" or "door" or "tank" or "engine" as a car.
 	The scent-description of a car is "metal parts and oil".
+
+Rule for writing a topic sentence about a car (called target car):
+	let N be 0;
+	repeat with C running through cars in location:
+		unless C is the alterna-shuttle or C is the truck:
+			increment N;
+			now C is mentioned;
+	if N is greater than 1:
+		say "There are [N in words] cars parked [if the location is offroad]illegally [end if]nearby. ";
+	otherwise:
+		say "Our car[one of] [--] a sub-sub-compact that looks like it might be outraced by a kid on a scooter [--][or] [--] which might better be described as a covered bicycle [--][or][at random] is parked [if the location is offroad]illegally [end if]nearby. "
 
 A car can be fueled or unfueled. A car is usually unfueled.
 


### PR DESCRIPTION
Allow the player (and the mechanic) to make a second car driveable. It is quite useless but does hopefully not break anything. I just couldn't come up with a good reason why the mechanic should refuse to fix a second car, when it is possible to get two cans of oil and two kinds of fuel.

The code that makes it impossible to create a car inside a container, such as another car, with the exception of the synthesizer, does perhaps not belong in this PR.

TODO:
- [x] Respond to attempts to get the mechanic to use the poppy oil