### PR TITLE
Add a full-screen map. Fixes #185 and #186

### DIFF
--- a/Counterfeit Monkey.inform/Source/story.ni
+++ b/Counterfeit Monkey.inform/Source/story.ni
@@ -73,7 +73,7 @@ Ultra Undo is an extension kindly written by Dannii Willis to use external file 
 
 Include version 1/160501 of Ultra Undo by Dannii Willis.
 
-The release number is 10.
+The release number is 11.
 
 Use scoring.
 Use static object grouping.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -409,7 +409,7 @@ An instructional rule (this is the teach enabling graphics rule):
 		make no decision;
 	unless glulx graphics is supported:
 		make no decision;
-	say "[first custom style]You can open a map window by typing GRAPHICS ON, and close it again with GRAPHICS OFF. You can also take a quick peek at a full-size map by typing MAP.[roman type]";
+	say "[first custom style]You can open a map window by typing MAP ON, and close it again with MAP OFF. You can also temporarily fill the window with the map by just typing MAP.[roman type]";
 	add the teach enabling graphics rule to the completed instruction list, if absent;
 	add the teach disabling graphics rule to the completed instruction list, if absent;
 	rule succeeds.
@@ -696,7 +696,7 @@ A last instructional rule (this is the teach disabling graphics rule):
 		make no decision;
 	if the graphics window is g-unpresent:
 		make no decision;
-	say "[first custom style]The map and compass can be switched off by typing GRAPHICS OFF. If you change your mind later, switch them back on with GRAPHICS ON.[roman type]";
+	say "[first custom style]The map and compass can be switched off by typing MAP OFF. If you change your mind later, switch them back on with MAP ON.[roman type]";
 	add the teach disabling graphics rule to the completed instruction list, if absent;
 	rule succeeds.
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -402,6 +402,17 @@ Check turning on tutorial mode:
 			otherwise:
 				stop the action.
 
+An instructional rule (this is the teach enabling graphics rule):
+	if the teach enabling graphics rule is listed in the completed instruction list:
+		make no decision;
+	if the graphics window is g-present:
+		make no decision;
+	unless glulx graphics is supported:
+		make no decision;
+	say "[first custom style]You can open a map window by typing GRAPHICS ON, and close it again with GRAPHICS OFF. You can also take a quick peek at a full-size map by typing MAP.[roman type]";
+	add the teach enabling graphics rule to the completed instruction list, if absent;
+	add the teach disabling graphics rule to the completed instruction list, if absent;
+	rule succeeds.
 
 An instructional rule (this is the teach examining thoroughness rule):
 	if the teach examining thoroughness rule is listed in the completed instruction list:
@@ -683,7 +694,7 @@ The teach disabling graphics rule is listed after the teach meta-features rule i
 A last instructional rule (this is the teach disabling graphics rule):
 	if the teach disabling graphics rule is listed in the completed instruction list:
 		make no decision;
-	unless glulx graphics is supported:
+	if the graphics window is g-unpresent:
 		make no decision;
 	say "[first custom style]The map and compass can be switched off by typing GRAPHICS OFF. If you change your mind later, switch them back on with GRAPHICS ON.[roman type]";
 	add the teach disabling graphics rule to the completed instruction list, if absent;

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
@@ -40,7 +40,7 @@ Ideal-width is a number that varies.
 
 To force the size of (win - a g-window) to (size - a number ):
 	(- glk_window_set_arrangement( glk_window_get_parent( {win}.(+ ref number +) ), {win}.(+ position +) + 14, {size}, GLK_NULL ); -).
-	
+
 To adjust width of the graphics window:
 	let original width be the width of the graphics window;
 	now ideal-width is the width of the measuring window / 2;
@@ -57,7 +57,9 @@ To adjust width of the graphics window:
 
 When identification ends (this is the open the graphics window rule):
 	if glulx graphics is supported:
-		unless graphics is disabled:
+		let main-width be the width of the main window;
+		let measure-width be the width of the measuring window;
+		unless graphics is disabled or main-width is less than 41 or measure-width is less than 405:
 			now current graphics drawing rule is the compass-drawing rule;
 			open the graphics window;
 			start looking for graphlinks.
@@ -76,7 +78,7 @@ The map concept borrows from commercial game minimaps that show goal locations a
 
 Like the compass rose in Bronze, the compass rose here shows exits in different shades depending on whether the rooms in those directions have already been visited. The compass is also hyperlinked so that the player can click on it as an alternative to typing directions. ]
 
-Figure of dim northwest is the file "grey-nw.png" ("dim northwest").
+[Figure of dim northwest is the file "grey-nw.png" ("dim northwest").
 Figure of dim north is the file "grey-n.png" ("dim north").
 Figure of dim northeast is the file "grey-ne.png" ("dim northeast").
 Figure of dim west is the file "grey-w.png" ("dim west").
@@ -85,7 +87,7 @@ Figure of dim southwest is the file "grey-sw.png" ("dim southwest").
 Figure of dim south is the file "grey-s.png" ("dim south").
 Figure of dim southeast is the file "grey-se.png" ("dim southeast").
 Figure of dim up is the file "grey-u.png" ("dim up").
-Figure of dim down is the file "grey-d.png" ("dim down").
+Figure of dim down is the file "grey-d.png" ("dim down").]
 
 Figure of northwest is the file "white-nw.png" ("northwest").
 Figure of north is the file "white-n.png" ("north").
@@ -109,14 +111,14 @@ Figure of new southeast is the file "blue-se.png" ("unvisited southeast").
 Figure of new up is the file "blue-u.png" ("unvisited up").
 Figure of new down is the file "blue-d.png" ("unvisited down").
 
-Figure of dim fore-port is the file "grey-fp.png" ("dim fore-port").
+[Figure of dim fore-port is the file "grey-fp.png" ("dim fore-port").
 Figure of dim fore is the file "grey-f.png" ("dim fore").
 Figure of dim fore-starboard is the file "grey-fsb.png" ("dim fore-starboard").
 Figure of dim port is the file "grey-p.png" ("dim port").
 Figure of dim starboard is the file "grey-sb.png" ("dim starboard").
 Figure of dim aft-port is the file "grey-ap.png" ("dim aft-port").
 Figure of dim aft is the file "grey-a.png" ("dim aft").
-Figure of dim aft-starboard is the file "grey-asb.png" ("dim aft-starboard").
+Figure of dim aft-starboard is the file "grey-asb.png" ("dim aft-starboard").]
 
 Figure of fore-port is the file "white-fp.png" ("fore-port").
 Figure of fore is the file "white-f.png" ("fore").
@@ -141,7 +143,7 @@ Figure of center-squiggle is the file "center-squiggle.png" ("center silcrow").
 
 [The following is a hack. Originally the figure name associations were all properties of the direction objects, but some sort of memory bug happened when image properties were added to the nautical directions. The result was that the map itself was reconfigured weirdly -- for instance, Slango's Head was declared in source to be aft from Slango's Bunk, but in the game model it would be port of Slango's Bunk instead.]
 
-To decide what figure-name is the dim image of (way - a direction):
+[To decide what figure-name is the dim image of (way - a direction):
 	if way is:
 		-- fore-port:
 			decide on figure of dim fore-port;
@@ -256,7 +258,7 @@ To decide what figure-name is the visited image of (way - a direction):
 		-- up:
 			decide on figure of up;
 		-- down:
-			decide on figure of down.
+			decide on figure of down.]
 
 A direction has a number called x-coordinate. A direction has a number called y-coordinate.
 
@@ -350,7 +352,7 @@ This is the compass-drawing rule:
 		establish compass graphlinks;
 		redraw the map and compass;
 
-To determine compass coordinates:
+[To determine compass coordinates:
 	let ZE be 0;
 	increase ZE by grid-margin;
 	let D be grid-size;
@@ -399,7 +401,7 @@ To determine compass coordinates:
 	now x-coordinate of south is D;
 	now y-coordinate of south is LM;
 	now x-coordinate of southeast is DD;
-	now y-coordinate of southeast is LM.
+	now y-coordinate of southeast is LM.]
 
 [Layer the image: a black background to fill in the top of the screen; blue for the bottom half so that if the map is too small, it will still look blue at the edges; then the map itself, proportionally scaled as large as it can reasonably be given the window dimensions; then the compass, built from the current circumstances.
 
@@ -417,18 +419,19 @@ To redraw the map and compass:
 		draw figure of background colour in graphics window at x 0 and y (((total height - scaled height) / 2) + scaled height) scaled to width ideal-width and height padding height;
 		[ Draw a black square at the top to cover any artifacts left over after changing height ]
 		draw a rectangle of color "$000000" in graphics window at x 0 and y 0 of width ideal-width and height (total height - scaled height) / 2;
-		determine compass coordinates;
-		draw Figure of center-squiggle in graphics window at x x-coordinate of north and y y-coordinate of west scaled to width grid-size and height grid-size;
-		repeat with way running through directions:
-			if the way is a listable exit and the way is not inside and the way is not outside:
-				let X be the x-coordinate of way;
-				let Y be the y-coordinate of way;
-				if the room way from the location is visited:
-					draw the visited image of the way in graphics window at x X and y Y scaled to width grid-size and height grid-size;
-				otherwise:
-					draw the unvisited image of the way in graphics window at x X and y Y scaled to width grid-size and height grid-size;
+		determine compass coordinates with window height total height;
+		draw compass.
+
+
+To determine compass coordinates with window height (height - a number):
+	(- DetermineCompassCoordinates({height}, (+ compass width +), (+ grid-size +)); -).
+
+To draw compass:
+	(- DrawCompass((+ graphics window +).(+ ref number +),(+ grid-size +)); -).
+
 
 Understand "graphics on" or "enable graphics" or "graphics" or "graphics mode" as enabling graphics. Enabling graphics is an action out of world.
+
 
 Include (-
 
@@ -475,6 +478,448 @@ Carry out disabling graphics:
 		say "[first custom style][bracket]Graphics are now disabled.[close bracket][roman type][paragraph break]";
 	otherwise:
 		say "[first custom style][bracket]Graphics are already disabled.[close bracket][roman type][paragraph break]".
+
+
+Include (-
+
+[ DetermineCompassCoordinates graphwin_height compass_width grid_size grid_margin
+    ze d dd ddd te um lm bee;
+
+	grid_margin = grid_size / 2;
+    ze = 0;
+    ze = ze + grid_margin;
+
+    d = grid_size;
+
+    dd = 2 * d;
+
+    ddd = compass_width;
+    te = graphwin_height - d * 4;
+
+    um = te + d;
+	lm = te + dd;
+
+    bee = graphwin_height - d;
+
+    d = d + grid_margin;
+    dd = dd + grid_margin;
+    ddd = ddd + grid_margin;
+
+    ! [15: now x-coordinate of up is ze]
+    WriteGProperty(10, (+ up +), (+ x-coordinate +),ze);
+    ! [16: now y-coordinate of up is bee]
+    WriteGProperty(10, (+ up +),(+ y-coordinate +),bee);
+    ! [17: now x-coordinate of down is dd]
+    WriteGProperty(10, (+ down +),(+ x-coordinate +),dd);
+    ! [18: now y-coordinate of down is bee]
+    WriteGProperty(10, (+ down +),(+ y-coordinate +),bee);
+    ! [19: now x-coordinate of fore-port is ze]
+    WriteGProperty(10, (+ fore-port +),(+ x-coordinate +),ze);
+    ! [20: now y-coordinate of fore-port is te]
+    WriteGProperty(10, (+ fore-port +),(+ y-coordinate +),te);
+    ! [21: now x-coordinate of fore is d]
+    WriteGProperty(10, (+ fore +),(+ x-coordinate +),d);
+    ! [22: now y-coordinate of fore is te]
+    WriteGProperty(10, (+ fore +),(+ y-coordinate +),te);
+    ! [23: now x-coordinate of fore-starboard is dd]
+    WriteGProperty(10, (+ fore-starboard +),(+ x-coordinate +),dd);
+    ! [24: now y-coordinate of fore-starboard is te]
+    WriteGProperty(10, (+ fore-starboard +),(+ y-coordinate +),te);
+    ! [25: now x-coordinate of port is ze]
+    WriteGProperty(10, (+ port +),(+ x-coordinate +),ze);
+    ! [26: now y-coordinate of port is um]
+    WriteGProperty(10, (+ port +),(+ y-coordinate +),um);
+    ! [27: now x-coordinate of starboard is dd]
+    WriteGProperty(10, (+ starboard +),(+ x-coordinate +),dd);
+    ! [28: now y-coordinate of starboard is um]
+    WriteGProperty(10, (+ starboard +),(+ y-coordinate +),um);
+    ! [29: now x-coordinate of aft-port is ze]
+    WriteGProperty(10, (+ aft-port +),(+ x-coordinate +),ze);
+    ! [30: now y-coordinate of aft-port is lm]
+    WriteGProperty(10, (+ aft-port +),(+ y-coordinate +),lm);
+    ! [31: now x-coordinate of aft is d]
+    WriteGProperty(10, (+ aft +),(+ x-coordinate +),d);
+    ! [32: now y-coordinate of aft is lm]
+    WriteGProperty(10, (+ aft +),(+ y-coordinate +),lm);
+    ! [33: now x-coordinate of aft-starboard is dd]
+    WriteGProperty(10, (+ aft-starboard +),(+ x-coordinate +),dd);
+    ! [34: now y-coordinate of aft-starboard is lm]
+    WriteGProperty(10, (+ aft-starboard +),(+ y-coordinate +),lm);
+    ! [35: now x-coordinate of northwest is ze]
+    WriteGProperty(10, (+ northwest +),(+ x-coordinate +),ze);
+    ! [36: now y-coordinate of northwest is te]
+    WriteGProperty(10, (+ northwest +),(+ y-coordinate +),te);
+    ! [37: now x-coordinate of north is d]
+    WriteGProperty(10, (+ north +),(+ x-coordinate +),d);
+    ! [38: now y-coordinate of north is te]
+    WriteGProperty(10, (+ north +),(+ y-coordinate +),te);
+    ! [39: now x-coordinate of northeast is dd]
+    WriteGProperty(10, (+ northeast +),(+ x-coordinate +),dd);
+    ! [40: now y-coordinate of northeast is te]
+    WriteGProperty(10, (+ northeast +),(+ y-coordinate +),te);
+    ! [41: now x-coordinate of west is ze]
+    WriteGProperty(10, (+ west +),(+ x-coordinate +),ze);
+    ! [42: now y-coordinate of west is um]
+    WriteGProperty(10, (+ west +),(+ y-coordinate +),um);
+    ! [43: now x-coordinate of east is dd]
+    WriteGProperty(10, (+ east +),(+ x-coordinate +),dd);
+    ! [44: now y-coordinate of east is um]
+    WriteGProperty(10, (+ east +),(+ y-coordinate +),um);
+    ! [45: now x-coordinate of southwest is ze]
+    WriteGProperty(10, (+ southwest +),(+ x-coordinate +),ze);
+    ! [46: now y-coordinate of southwest is lm]
+    WriteGProperty(10, (+ southwest +),(+ y-coordinate +),lm);
+    ! [47: now x-coordinate of south is d]
+    WriteGProperty(10, (+ south +),(+ x-coordinate +),d);
+    ! [48: now y-coordinate of south is lm]
+    WriteGProperty(10, (+ south +),(+ y-coordinate +),lm);
+    ! [49: now x-coordinate of southeast is dd]
+    WriteGProperty(10, (+ southeast +),(+ x-coordinate +),dd);
+    ! [50: now y-coordinate of southeast is lm]
+    WriteGProperty(10, (+ southeast +),(+ y-coordinate +),lm);
+    rfalse;
+];
+
+[ VisitedImageOf way;
+    switch (way)
+    {
+		(+ fore-port +):
+		return (+ figure of fore-port +);
+
+		(+ fore +):
+			return (+ figure of fore +);
+
+        (+ fore-starboard +):
+			return (+ figure of fore-starboard +);
+
+        (+ port +):
+			return (+ figure of port +);
+
+        (+ starboard +):
+			return (+ figure of starboard +);
+
+        (+ aft-port +):
+			return (+ figure of aft-port +);
+
+        (+ aft +):
+			return (+ figure of aft +);
+
+        (+ aft-starboard +):
+			return (+ figure of aft-starboard +);
+
+        (+ northwest +):
+			return (+ figure of northwest +);
+
+        (+ north +):
+			return (+ figure of north +);
+
+        (+ northeast +):
+			return (+ figure of northeast +);
+
+        (+ west +):
+			return (+ figure of west +);
+
+        (+ east +):
+			return (+ figure of east +);
+
+        (+ southwest +):
+			return (+ figure of southwest +);
+
+        (+ south +):
+			return (+ figure of south +);
+
+        (+ southeast +):
+			return (+ figure of southeast +);
+
+        (+ up +):
+			return (+ figure of up +);
+
+         (+ down +):
+			return (+ figure of down +);
+    }
+
+    return (+ figure of cover +);
+];
+
+[ UnvisitedImageOf way;
+    switch (way)
+    {
+		(+ fore-port +):
+		return (+ figure of new fore-port +);
+
+		(+ fore +):
+			return (+ figure of new fore +);
+
+        (+ fore-starboard +):
+			return (+ figure of new fore-starboard +);
+
+        (+ port +):
+			return (+ figure of new port +);
+
+        (+ starboard +):
+			return (+ figure of new starboard +);
+
+        (+ aft-port +):
+			return (+ figure of new aft-port +);
+
+        (+ aft +):
+			return (+ figure of new aft +);
+
+        (+ aft-starboard +):
+			return (+ figure of new aft-starboard +);
+
+        (+ northwest +):
+			return (+ figure of new northwest +);
+
+        (+ north +):
+			return (+ figure of new north +);
+
+        (+ northeast +):
+			return (+ figure of new northeast +);
+
+        (+ west +):
+			return (+ figure of new west +);
+
+        (+ east +):
+			return (+ figure of new east +);
+
+        (+ southwest +):
+			return (+ figure of new southwest +);
+
+        (+ south +):
+			return (+ figure of new south +);
+
+        (+ southeast +):
+			return (+ figure of new southeast +);
+
+        (+ up +):
+			return (+ figure of new up +);
+
+         (+ down +):
+			return (+ figure of new down +);
+    }
+
+    return (+ figure of cover +);
+];
+
+
+[ DrawCompass graphwin grid_size x y way room;
+    glk_image_draw_scaled( graphwin, ResourceIDsOfFigures-->( (+ figure of center-squiggle +) ), GProperty(10, (+ north +),(+ x-coordinate +)), GProperty(10, (+ west +),(+ y-coordinate +)), grid_size, grid_size);
+    ! repeat with way running through directions
+
+    ! Class K3_direction
+
+    for (way=IK3_First: way: way=way.IK3_Link)
+	{
+		if (way ~= in_obj && way ~= out_obj)
+		{
+			room = MapConnection(real_location, way);
+			if (room ~= nothing)
+			{
+				x = GProperty(10, way,(+ x-coordinate +));
+				y = GProperty(10, way,(+ y-coordinate +));
+				if (room has visited)
+				{
+					glk_image_draw_scaled( graphwin, ResourceIDsOfFigures-->(VisitedImageOf(way)), x, y, grid_size, grid_size);
+				} else {
+					glk_image_draw_scaled( graphwin, ResourceIDsOfFigures-->(UnvisitedImageOf(way)), x, y, grid_size, grid_size);
+				}
+			}
+		}
+	}
+];
+
+
+[ WaitForInputInGraphWin win done;
+	done = false;
+	if (win == -1) {
+		rfalse;
+	}
+	if (glk_gestalt(gestalt_GraphicsCharInput, 0))
+	{
+		glk_request_char_event(win);
+    }
+
+    glk_request_mouse_event(win);
+    while (~~done) {
+		glk_select(gg_event);
+
+		switch (gg_event-->0)
+		{
+			evtype_Arrange:
+				DrawBigMap(win);
+			evtype_CharInput:
+				done = true;
+			evtype_MouseInput:
+				done = true;
+		}
+    }
+	glk_cancel_char_event(win);
+];
+
+[ GraphwinOnly graphwin;
+	glk_window_close(gg_mainwin, GLK_NULL);
+
+	graphwin = glk_window_open(0, 0, 0, wintype_Graphics, GG_MAINWIN_ROCK);
+	if (graphwin == -1)
+		rfalse;
+
+	DrawBigMap(graphwin);
+	WaitForInputInGraphWin(graphwin);
+
+	!close the graphics window;
+	glk_window_close(graphwin, GLK_NULL);
+];
+
+
+[ DrawBigMap graphwin
+    map_top
+    ideal_width
+    real_ideal
+    real_height
+    ratio
+    scaled_height
+    scaled_height_real
+    half_height
+    fullwidth
+    fullheight
+    map_ratio
+    compass_width
+    grid_size
+    width_quarter
+    height_sixth
+    vertical_offset
+    ;
+
+    map_top = 0;
+
+    ! let real-ideal be the width of the graphics window
+
+    ! Get the graphics window width
+    glk_window_get_size(graphwin, gg_arguments, 0);
+    fullwidth = gg_arguments-->0;
+    real_ideal = NUMBER_TY_to_REAL_NUMBER_TY(fullwidth);
+    ideal_width = fullwidth;
+
+    ! Get the graphics window height
+	glk_window_get_size(graphwin, 0, gg_arguments);
+	fullheight = gg_arguments-->0;
+
+	! let real-height be the height of the graphics window * 1.21
+    ! REAL_NUMBER_TY_Divide(1210, 1000) is 1067114824
+	real_height = REAL_NUMBER_TY_Times(NUMBER_TY_to_REAL_NUMBER_TY(fullheight), 1067114824);
+	ratio = REAL_NUMBER_TY_Divide(real_ideal, real_height);
+
+    ! REAL_NUMBER_TY_Divide(722, 860) is 1062660473
+    map_ratio = 1062660473;
+
+    ! if ratio > map_ratio
+    if (REAL_NUMBER_TY_Compare(ratio, map_ratio) > 0)
+    {
+        real_ideal = REAL_NUMBER_TY_Times(real_height, map_ratio);
+        ideal_width = REAL_NUMBER_TY_to_NUMBER_TY(real_ideal);
+        map_top = -1;
+    }
+
+	scaled_height_real = REAL_NUMBER_TY_Divide(real_ideal, map_ratio);
+    scaled_height = REAL_NUMBER_TY_to_NUMBER_TY(scaled_height_real);
+
+    vertical_offset = 0;
+    map_top = IntegerDivide(fullheight - scaled_height, 2);
+    half_height = IntegerDivide(fullheight, 2) + 1;
+
+	if (map_top <= 0)
+	{
+		! 0.02 REAL_NUMBER_TY_Divide(2, 100) is 1017370378
+		vertical_offset = REAL_NUMBER_TY_to_NUMBER_TY(REAL_NUMBER_TY_Times(scaled_height_real, 1017370378));
+
+		map_top = map_top - vertical_offset;
+
+		! fill window with blue background colour
+		glk_image_draw_scaled(graphwin, ResourceIDsOfFigures-->( (+ figure of background colour +) ), 0, 0, fullwidth, fullheight);
+    } else {
+		! draw rectangle of blue background colour
+		glk_image_draw_scaled(graphwin, ResourceIDsOfFigures-->( (+ figure of background colour +) ), 0, half_height, fullwidth, half_height );
+
+		! draw black rectangle
+		glk_window_fill_rect( graphwin, 0 , 0, 0, fullwidth, half_height );
+    }
+
+    ! draw the local map of the location
+    glk_image_draw_scaled(graphwin, ResourceIDsOfFigures-->( GProperty(OBJECT_TY, real_location, (+ local map +) ) ), IntegerDivide(fullwidth - ideal_width, 2), map_top, ideal_width, scaled_height);
+
+    width_quarter = ideal_width / 4;
+	height_sixth = fullheight / 6;
+
+	if (width_quarter > height_sixth)
+		compass_width = height_sixth;
+	else
+		compass_width = width_quarter;
+
+	grid_size = compass_width / 3;
+
+    DetermineCompassCoordinates(fullheight, compass_width, grid_size);
+    DrawCompass(graphwin, grid_size);
+];
+
+-).
+
+
+Understand "map" as big-map-showing. Big-map-showing is an action out of world.
+
+Carry out big-map-showing:
+	unless glulx graphics is supported:
+		say "[first custom style][bracket]This interpreter does not support displaying 	graphics.[close bracket][roman type][paragraph break]" instead;
+	close the status window;
+	close the measuring window;
+	let was-showing-map be false;
+	if the graphics window is g-present:
+		now was-showing-map is true;
+		close the graphics window;
+	close all but graphwin;
+	open the measuring window;
+	reopen status;
+	if was-showing-map is true:
+		open the graphics window;
+		adjust width of the graphics window;
+		redraw the map and compass;
+		start looking for graphlinks;
+	try looking.
+
+
+To close all but graphwin:
+	(- 	GraphwinOnly(); -).
+
+To reopen status:
+	(- 	if (gg_statuswin == 0) gg_statuswin = glk_window_open(gg_mainwin, winmethod_Fixed + winmethod_Above, 1, wintype_TextGrid, GG_STATUSWIN_ROCK); -).
+
+
+Understand "inline map" and "in-line map" as inline-map-showing. Inline-map-showing is an action out of world.
+
+Carry out inline-map-showing:
+	unless glulx graphics is supported:
+		say "[first custom style][bracket]This interpreter does not support displaying 	graphics.[close bracket][roman type][paragraph break]" instead;
+	let was-showing-map be false;
+	if the graphics window is g-present:
+		now was-showing-map is true;
+		close the graphics window;
+	let scaled width be the width of the measuring window;
+	let result be the result of displaying the local map of the location scaled to width scaled width and height scaled width / map-ratio to the nearest whole number;
+	if result is 0:
+		say "[first custom style][bracket]Failed to display inline map.[close bracket][roman type][line break]";
+	if was-showing-map is true:
+		if result is not 0:
+			custom-wait for any key;
+			say line break;
+		open the graphics window;
+		adjust width of the graphics window;
+		redraw the map and compass;
+		start looking for graphlinks.
+
+To decide which number is the result of displaying (image - a figure-name) scaled to width (width - a number) and height (height - a number):
+	(- glk_image_draw_scaled( gg_mainwin, ResourceIDsOfFigures-->( {image} ), imagealign_InlineDown, 0, {width}, {height} ); -).
+
+
 
 Chapter 2 - Sounds
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Multimedia.i7x
@@ -430,55 +430,8 @@ To draw compass:
 	(- DrawCompass((+ graphics window +).(+ ref number +),(+ grid-size +)); -).
 
 
-Understand "graphics on" or "enable graphics" or "graphics" or "graphics mode" as enabling graphics. Enabling graphics is an action out of world.
 
-
-Include (-
-
-Array graphics_disabled --> 1;
-
--) after "Definitions.i6t".
-
-To set graphics disabled flag:
-    (- if (arrayAsMillisecs(totalTestStartTime) == 0) @protect graphics_disabled 4;
-    graphics_disabled-->0 = 1; -)
-
-[We can only have one restore and restart protected variable at a time, so skip protecting the graphics_disabled flag if we are measuring total play time.]
-
-To unset graphics disabled flag:
-    (- graphics_disabled-->0 = 0; -)
-
-To decide whether graphics is disabled:
-	(- graphics_disabled-->0 -).
-
-
-Carry out enabling graphics:
-	unless glulx graphics is supported:
-		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
-	if the graphics window is g-present:
-		say "[first custom style][bracket]Graphics are already enabled.[close bracket][roman type][paragraph break]";
-	otherwise:
-		unless the measuring window is g-present:
-			open the measuring window;
-		now current graphics drawing rule is the compass-drawing rule;
-		open the graphics window;
-		start looking for graphlinks;
-		unset graphics disabled flag;
-		say "[first custom style][bracket]Graphics are now enabled.[close bracket][roman type][paragraph break]".
-
-Understand "graphics off" or "text only" or "text mode" as disabling graphics. Disabling graphics is an action out of world.
-
-Carry out disabling graphics:
-	unless glulx graphics is supported:
-		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
-	add the teach disabling graphics rule to the completed instruction list, if absent;
-	if the graphics window is g-present:
-		close the graphics window;
-		set graphics disabled flag;
-		say "[first custom style][bracket]Graphics are now disabled.[close bracket][roman type][paragraph break]";
-	otherwise:
-		say "[first custom style][bracket]Graphics are already disabled.[close bracket][roman type][paragraph break]".
-
+Section 2 - Full-window map
 
 Include (-
 
@@ -864,12 +817,13 @@ Include (-
 
 -).
 
+Seen-map is a truth state that varies. Seen-map is initially false.
 
 Understand "map" as big-map-showing. Big-map-showing is an action out of world.
 
 Carry out big-map-showing:
 	unless glulx graphics is supported:
-		say "[first custom style][bracket]This interpreter does not support displaying 	graphics.[close bracket][roman type][paragraph break]" instead;
+		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
 	close the status window;
 	close the measuring window;
 	let was-showing-map be false;
@@ -884,7 +838,11 @@ Carry out big-map-showing:
 		adjust width of the graphics window;
 		redraw the map and compass;
 		start looking for graphlinks;
-	try looking.
+		now seen-map is true;
+	try looking;
+	if seen-map is false:
+		say "[first custom style][bracket]You can open the map in a split window by typing MAP ON.[close bracket][roman type][paragraph break]";
+		now seen-map is true.
 
 
 To close all but graphwin:
@@ -898,7 +856,7 @@ Understand "inline map" and "in-line map" as inline-map-showing. Inline-map-show
 
 Carry out inline-map-showing:
 	unless glulx graphics is supported:
-		say "[first custom style][bracket]This interpreter does not support displaying 	graphics.[close bracket][roman type][paragraph break]" instead;
+		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
 	let was-showing-map be false;
 	if the graphics window is g-present:
 		now was-showing-map is true;
@@ -919,6 +877,58 @@ Carry out inline-map-showing:
 To decide which number is the result of displaying (image - a figure-name) scaled to width (width - a number) and height (height - a number):
 	(- glk_image_draw_scaled( gg_mainwin, ResourceIDsOfFigures-->( {image} ), imagealign_InlineDown, 0, {width}, {height} ); -).
 
+
+
+Section 3 - Enabling and disabling the map
+
+Understand "map on" or "graphics on" or "enable graphics" or "graphics" or "graphics mode" as enabling graphics. Enabling graphics is an action out of world.
+
+
+Include (-
+
+Array graphics_disabled --> 1;
+
+-) after "Definitions.i6t".
+
+To set graphics disabled flag:
+    (- if (arrayAsMillisecs(totalTestStartTime) == 0) @protect graphics_disabled 4;
+    graphics_disabled-->0 = 1; -)
+
+[We can only have one restore and restart protected variable at a time, so skip protecting the graphics_disabled flag if we are measuring total play time.]
+
+To unset graphics disabled flag:
+    (- graphics_disabled-->0 = 0; -)
+
+To decide whether graphics is disabled:
+	(- graphics_disabled-->0 -).
+
+
+Carry out enabling graphics:
+	unless glulx graphics is supported:
+		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
+	if the graphics window is g-present:
+		say "[first custom style][bracket]The map is already enabled.[close bracket][roman type][paragraph break]";
+	otherwise:
+		unless the measuring window is g-present:
+			open the measuring window;
+		now current graphics drawing rule is the compass-drawing rule;
+		open the graphics window;
+		start looking for graphlinks;
+		unset graphics disabled flag;
+		say "[first custom style][bracket]The map is now enabled. Type MAP OFF to turn it off again.[close bracket][roman type][paragraph break]".
+
+Understand "map off" or "graphics off" or "text only" or "text mode" as disabling graphics. Disabling graphics is an action out of world.
+
+Carry out disabling graphics:
+	unless glulx graphics is supported:
+		say "[first custom style][bracket]This interpreter does not support displaying graphics.[close bracket][roman type][paragraph break]" instead;
+	add the teach disabling graphics rule to the completed instruction list, if absent;
+	if the graphics window is g-present:
+		close the graphics window;
+		set graphics disabled flag;
+		say "[first custom style][bracket]The map is now disabled. Type MAP ON to turn it back on, or just MAP to show it at full window size.[close bracket][roman type][paragraph break]";
+	otherwise:
+		say "[first custom style][bracket]The map is already disabled.[close bracket][roman type][paragraph break]".
 
 
 Chapter 2 - Sounds

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Presentation Details.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Presentation Details.i7x
@@ -621,7 +621,7 @@ INVENTORY TALL, INVENTORY WIDE and INVENTORY UTILITARIAN change the way inventor
 
 In a location, LOOK CAREFULLY will print the room description with object names in bold. If you would like to experience the whole game this way, try HIGHLIGHTING ON.
 
-If your interpreter supports graphics, GRAPHICS OFF will hide the map and GRAPHICS ON will show it again.
+If your interpreter supports graphics, MAP OFF will hide the map window and MAP ON will show it again. Just typing MAP will temporarily show a larger map.
 
 GO TO a location will take us to the place named, even if that's some distance away.
 


### PR DESCRIPTION
Show a full-window map with the new command MAP. Also renames GRAPHICS ON and GRAPHICS OFF to MAP ON and MAP OFF, respectively. Some new instructional messages are added as well.