### PR TITLE
Prevent shower drain softlock

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -1708,6 +1708,9 @@ Sanity-check washing a person who is not the player:
 		say "[The noun] could probably use a wash, but on the whole I don't see the point." instead;
 	say "Bathing people other than myself is kind of over-intimate." instead.
 
+Instead of entering a bath:
+	try bathing.
+
 A public restroom is a kind of room.
 
 A toilet-stall is a kind of container. The printed name of a toilet-stall is always "toilet stall". Rule for printing the plural name of a toilet-stall: say "toilet stalls". Understand "stall" as a toilet-stall. Understand "stalls" as the plural of a toilet-stall. A toilet-stall is always fixed in place and enterable and openable.


### PR DESCRIPTION
This MR fixes this funny bug:

> \>get in shower
> (getting off the toilet)
> You get into the shower.
> 
> \>turn on shower
> As we turn on the water, yourself washes down the drain.
> 
> *** Run-time problem P43: Attempt to remove the player from play.

(Of course, if escaping Atlantis were as easy as this, Alex would have tried it by now.)

You can even softlock yourself by entering a bath, dropping all, then turning on the bath!

> \>enter bath
> We get into the bath.
> 
> \>drop all
> *The Problem of Adjectives*: We put down *The Problem of Adjectives*.
> ring: We put down the ring.
> key: We put down the key.
> as: We put down the as.
> Origin Paste: We put down the Origin Paste.
> backpack: We put down the backpack.
> O-remover: We put down the O-remover.
> 
> \>exit bath
> We get out of the bath.
> 
> \>turn on bath
> As we turn on the water, the O-remover, the backpack, the Origin Paste, the as, the key, the ring, and *The Problem of Adjectives* washes down the drain.

This behavior is governed by this rule in Liquids.i7x:

```
Before switching on a switched off tap (called target tap):
	let the target sink be a random container which incorporates the target tap;
	if the target sink is not nothing:
		[This works because we only allow the soap and derivates in sinks]
		if there is a non-empty sink (called soap-sink) in location and there is a thing (called soap-thing) which is not tap-water in soap-sink:
			now soap-thing is in target sink;
		unless the target sink is empty:
			say "As we turn on the water, [the list of things in target sink with definite articles] washes down the drain.";
			repeat with item running through things in target sink:
				if item is the soap or item is proffered by the soap:
					move item to repository;
					move soap to soap dispenser;
				otherwise:
					now the item is nowhere;
			move tap-water to target sink;
			now target tap is switched on;
			stop the action;
```
which seems to assume it only applies to sinks, but it also applies to baths, and baths are enterable!

So my fix is to add this rule:

```
Instead of entering a bath:
	try bathing.
```

because the block bathing rule simply says:

`"[We] [don't] have time for a bath."`

So the new behavior is:

> \>enter bath
> We don't have time for a bath.

Another strategy could be to fix this by changing the rule in Liquids.i7x to say "let the target sink be a random sink..." instead of "let the target sink be a random container..." to disable the washing-away for baths entirely, but considering that a rule exists to block inserting things into baths/sinks, I figure it's a better idea to not let you in the bath in the first place, since it seems like a loophole.