### PR TITLE
don't hesitate to try backtracking through the tall window

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Animal Actions and Human Conversation.i7x
@@ -6181,7 +6181,7 @@ Test attacks with "establish / hit atlantida with sword / hit atlantida with foi
 Section 13 - Scene Interlude with Guards
 
 
-Sanity-check going through the tall window when Atlantida-refreshed is off-stage:
+Sanity-check going north through the tall window when Atlantida-refreshed is off-stage:
 	if story viewpoint is second person singular:
 		say "[We] could do that. [We] could climb out that window and not look back. It would be faster, easier, unquestionably safer. But what about the people we're leaving behind? What about my father and Professor Higgate? What about the protesters who got arrested today?
 


### PR DESCRIPTION
Currently, attempting to backtrack south through the tall window from the Precarious Perch can trigger a confirmation prompt.

This PR fixes that. Now the behavior is:

> \>s
> It's locked again. There's no way for you but forward from here.

This edits a pretty important rule, so I'd appreciate confirmation that I'm not breaking anything :)