### PR TITLE
Restore search engine descriptions

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act V Atlantida Herself.i7x
@@ -295,7 +295,7 @@ Test surveillance with "x computer / x screen / turn on computer / select securi
 
 Test survey with "test surveillance" in Surveillance Room.
 
-The surveillance computer runs a search engine called access-database. The data table of access-database is the Table of Access Data.
+The surveillance computer runs a search engine called access-database. The description of access-database is "[We] can type search terms to look for data records.". The data table of access-database is the Table of Access Data.
 
 Table of Access Data
 topic	title	data

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -2037,8 +2037,7 @@ The description of a keyboard is usually "Arranged in the Dvorak layout preferre
 
 When play begins (this is the search engines rule):
 	repeat with item running through search engines:
-		now the results-found response of item is "The search turns up the following results:";
-		now the description of the item is "[We] can type search terms to look for data records."
+		now the results-found response of item is "The search turns up the following results:".
 
 Chapter 2 - Substances
 


### PR DESCRIPTION
Currently, turning on the ebook reader yields this message:

> \>switch on ebook reader
> The ebook reader chimes cheerfully.
> 
> We can type search terms to look for data records.

That last line is the description of Book search. But Book search's description is declared as:

`The description of Book search is "There is a long, scrolling list of books, with titles on economics, biography, linguistics, and history. A search bubble allows the user to search for specific genres or titles."`

This description is nowhere to be found ingame due to the search engines rule:

```
When play begins (this is the search engines rule):
	repeat with item running through search engines:
		now the results-found response of item is "The search turns up the following results:";
		now the description of the item is "[We] can type search terms to look for data records."
```

This issue also affects the secretary's computer's search engine, clobbering `A browser comes up, with a search box for accessing departmental information.`. The third and only other search engine in the game is access-database, which is on the surveillance computer. It does *not* have a description declared, so it relies on this rule.

So, this pull request adds a description declaration for the surveillance computer's search engine and removes the description-overriding line from the search engines rule. This restores the descriptions of Book search and the secretary's computer's search engine.

The new behavior is:

> \>switch on ebook reader
> The ebook reader chimes cheerfully.
> 
> There is a long, scrolling list of books, with titles on economics, biography, linguistics, and history. A search bubble allows the user to search for specific genres or titles.

Which I especially like because it hints that you can **scroll** the ebook reader, which is an action that exists for the ebook reader and nothing else. This pull request similarly restores the description of the secretary's computer's search engine.

