### PR TITLE
Make room names in sentences look more natural

### DIFF
--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act I Among Sightseers.i7x
@@ -251,7 +251,7 @@ The typographer's office is a facade in Sigil Street. It is scenery.
 Instead of looking toward Back Alley:
 	say "It doesn't look like there's anything interesting back that way."
 
-Back Alley is south of Sigil Street. The description is "[one of]This isn't much, is it? Just[or]There is nothing here but[stopping] the back sides of a couple of [yellow buildings], some peeling yellow paint[one of], and[or];[stopping] not even much by way of windows to look in through. [if Sigil Street is unvisited]I think the place where [we] had the procedure done is just a block or two away, but I've already lost the door. I imagine they change it. [end if]
+Back Alley is south of Sigil Street. It is improper-named. The description is "[one of]This isn't much, is it? Just[or]There is nothing here but[stopping] the back sides of a couple of [yellow buildings], some peeling yellow paint[one of], and[or];[stopping] not even much by way of windows to look in through. [if Sigil Street is unvisited]I think the place where [we] had the procedure done is just a block or two away, but I've already lost the door. I imagine they change it. [end if]
 
 This alley runs north to the open street, towards the town square[if Sigil Street is unvisited]. That's the way [we][']ll want to go first[end if]."
 The dull house-back is a facade in Back Alley. It fronts south. It is scenery. The description is "The owners of the house obviously didn't want a view in this direction, as there aren't any windows to see through, just a wall scarred by decades of occasional remodeling."
@@ -1102,7 +1102,7 @@ But since I was a tall blond male at the time, I don't think he can remember the
 
 Section 3 - Church Forecourt
 
-The Church Forecourt is [south of Food Corner,] northwest of Fair, west of Park Center, [southwest of Postcard Stalls,] and north of Midway.
+The Church Forecourt is [south of Food Corner,] northwest of Fair, west of Park Center, [southwest of Postcard Stalls,] and north of Midway. The Church Forecourt is improper-named.
 
 Rule for distantly describing the Church Forecourt:
 	if the player is in New Church:
@@ -2198,7 +2198,7 @@ Chapter 1 - City Walls
 
 Section 1 - Old City Walls
 
-The Old City Walls are north of the Monumental Staircase. Understand "wall" as Old City Walls. The description is "Only portions of the old walls still stand, but you can walk along what remains, as though you were defending the place. They're a me[ter] and a half wide, made of ashlar blocks. On the vertical faces these blocks are still rough, but underfoot they have been worn smooth by the passage of many defenders and (subsequently) tourists. One of the [defaced ashlar block]s in the wall has even been defaced, some old inscription gouged out.[one of]
+The Old City Walls are north of the Monumental Staircase. The Old City Walls are plural-named. Understand "wall" as Old City Walls. The description is "Only portions of the old walls still stand, but you can walk along what remains, as though you were defending the place. They're a me[ter] and a half wide, made of ashlar blocks. On the vertical faces these blocks are still rough, but underfoot they have been worn smooth by the passage of many defenders and (subsequently) tourists. One of the [defaced ashlar block]s in the wall has even been defaced, some old inscription gouged out.[one of]
 
 I used to like to climb around up here when I was a kid. I made believe[--] oh, you'll think it's silly.[or][stopping]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
@@ -64,7 +64,7 @@ aquarium-exterior is a facade in Deep Street. It fronts east. The printed name i
 	The description is "[if Aquarium is visited]The outside manages to give an impression of poverty, gloom, and probable drug use; though, having seen the inside, I am going to guess that the real issues are sloth and kookiness[otherwise]I've never been inside the Aquarium: the outside never looked terribly savory. Perhaps that's the point[end if]."
 
 Rule for writing a topic sentence about aquarium-exterior when aquarium-exterior is not as-yet-unknown:
-	say "[if boldening is true][bold type][end if]The Aquarium Bookstore[roman type] is to the east. [if aquarium-closed-sign is in location]There's a closed sign in the window and a forbidding atmosphere[otherwise]It's dim inside, but occasional movements suggest that the proprietor, Slango's friend Lena, is inside[end if]. "
+	say "[The Aquarium] is to the east. [if aquarium-closed-sign is in location]There's a closed sign in the window and a forbidding atmosphere[otherwise]It's dim inside, but occasional movements suggest that the proprietor, Slango's friend Lena, is inside[end if]. "
 
 A ranking rule when aquarium-exterior is not as-yet-unknown and Aquarium is visited and a car (called target) is in the location:
 	increase description-rank of the target by 20.

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act II Among Smugglers.i7x
@@ -115,7 +115,7 @@ After going from the Aquarium when Slango is in the Counterfeit Monkey:
 
 Section 2 - The Aquarium
 
-The Aquarium Bookstore is east of Deep Street. It is a privately-controlled proper-named checkpoint room. It is indoors. The description is "The shop takes its name from the [collection of fish] mounted on every wall: swordfish, bass, other things I don't recogn[ize]. Underneath these dubious tokens, the walls are covered with bookshelves, and there are stacks of books on the floor where the shelves have proven insufficient."
+The Aquarium Bookstore is east of Deep Street. It is a privately-controlled improper-named checkpoint room. It is indoors. The description is "The shop takes its name from the [collection of fish] mounted on every wall: swordfish, bass, other things I don't recogn[ize]. Underneath these dubious tokens, the walls are covered with bookshelves, and there are stacks of books on the floor where the shelves have proven insufficient."
 
 The aquarium-shelving is scenery in the aquarium. Understand "shelves" or "bookshelves" or "shelving" as the aquarium-shelving. The printed name is "shelving". The description is "They're completely crammed with books."
 
@@ -590,7 +590,7 @@ Rule for printing the name of the leaflet while listing contents of something:
 
 Section 8 - Docks
 
-The Docks are north of the Fish Market. It is checkpoint. The description is "Here are some dozens of [boats] tied up: some of them are small to medium-sized fishing craft, some tourist boats for trips around the island, some merely ferries to the deeper harbor where the cruise ships anchor."
+The Docks are north of the Fish Market. They are plural-named and checkpoint. The description is "Here are some dozens of [boats] tied up: some of them are small to medium-sized fishing craft, some tourist boats for trips around the island, some merely ferries to the deeper harbor where the cruise ships anchor."
 
 The boats are scenery in the Docks. Understand "craft" or "fishing craft" or "tourist" or "ferries" as the boats. The description is "I know nothing about boats. You, on the other hand, appear to have an unnerving awareness of which of these craft are here on legal business and which are engaged in some form of smuggling or refugee-assistance."
 
@@ -639,7 +639,7 @@ Section 9 - Counterfeit Monkey
 
 [The concept of the Monkey came fairly early.]
 
-The Counterfeit Monkey is west of the Docks. It is proper-named and indoors. The description is "[one of]It takes a minute for us to adjust to the light in here. [or]Infamously this pub was raided in 1929, the year that the Bureau developed its first meager attempt at an Authentication Scope, and dozens of smugglers and fraudulent businessmen went to jail. But neither that raid nor subsequent scrutiny has ever shut the place down entirely. [or][stopping]Built when people were a bit shorter and ceilings were a bit lower, the Counterfeit Monkey is always smoky and never well lit, even in the middle of the day."
+The Counterfeit Monkey is west of the Docks. It is improper-named and indoors. The description is "[one of]It takes a minute for us to adjust to the light in here. [or]Infamously this pub was raided in 1929, the year that the Bureau developed its first meager attempt at an Authentication Scope, and dozens of smugglers and fraudulent businessmen went to jail. But neither that raid nor subsequent scrutiny has ever shut the place down entirely. [or][stopping]Built when people were a bit shorter and ceilings were a bit lower, the Counterfeit Monkey is always smoky and never well lit, even in the middle of the day."
 
 Out-direction of Counterfeit Monkey is east. [To the docks]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act III Among Scholars.i7x
@@ -155,7 +155,7 @@ The hotel has recently had a face lift, with the silly old ornamentation pried o
 If you are my mother, you call this style Atlantean Postmodern. Less kindly, it is something from the sweaty dreams of an upscale swimming-pool installer."
 
 
-Fleur d'Or lobby is indoors, proper-named and southern. The room divider is a scenery thing in Fleur d'Or Lobby. The printed name is "sheet of frosted glass". Understand "glass" or "sheet" or "sheet of" or "frosted" or "annotation" or "primordial" or "primeval" or "sea" as the room divider. The description is "The glass is a good three quarters of an inch thick, and looks very sturdy. The etched letters glow or fade out again depending on the changing light conditions in the lobby.
+Fleur d'Or lobby is indoors, improper-named and southern. The room divider is a scenery thing in Fleur d'Or Lobby. The printed name is "sheet of frosted glass". Understand "glass" or "sheet" or "sheet of" or "frosted" or "annotation" or "primordial" or "primeval" or "sea" as the room divider. The description is "The glass is a good three quarters of an inch thick, and looks very sturdy. The etched letters glow or fade out again depending on the changing light conditions in the lobby.
 
 Annotation in the corner indicates that this is a commissioned artwork by Anne Landis Rosehip, entitled 'The Primeval Sea.'"
 
@@ -231,7 +231,7 @@ Rule for writing a topic sentence about the piano:
 
 Section 4 - Drinks Club
 
-Fleur d'Or Drinks Club is west of Fleur d'Or Lobby. It is indoors, checkpoint, proper-named and southern. The description is "The back wall is dramatically decorated with bottled liquors of all sorts, from gin to cachaça; there's a giant bottle of Campari, taller than your average three-year-old, with a red ribbon around its neck.
+Fleur d'Or Drinks Club is west of Fleur d'Or Lobby. It is indoors, checkpoint, improper-named and southern. The description is "The back wall is dramatically decorated with bottled liquors of all sorts, from gin to cachaça; there's a giant bottle of Campari, taller than your average three-year-old, with a red ribbon around its neck.
 
 What makes this place technically a drinks club rather than a bar is its lic[ense] to serve letter-manufactured food and drink. [A toolkit] on the [dor-bar-top] contains [a list of things *in the toolkit], ready to be transformed into their respective cocktails."
 
@@ -355,7 +355,7 @@ The apartment complex is a facade in Palm Square. The initial appearance is "I l
 
 Section 2 - Babel Cafe
 
-South of Palm Square is Babel Café. Understand "cafe" as the Babel Café. The description of Babel Café is "Through many changes of management, this institution has fed the denizens of the university and ignored their semi-sedition." Babel Café is indoors, proper-named and southern.
+South of Palm Square is Babel Café. Understand "cafe" as the Babel Café. The description of Babel Café is "Through many changes of management, this institution has fed the denizens of the university and ignored their semi-sedition." Babel Café is indoors, improper-named and southern.
 
 Out-direction of Babel Café is north. [Back to Palm Square]
 
@@ -388,7 +388,7 @@ Section 3 - Apartment Window
 
 Southwest of Palm Square is a apartment door. apartment door is a lockable locked door. It is scenery. Southwest of apartment door is My Apartment.
 
-My Apartment is southern checkpoint. Understand "home" as My Apartment.
+My Apartment is southern proper-named checkpoint. Understand "home" as My Apartment.
 
 Understand "go home" as home-going. Home-going is an action applying to nothing.
 
@@ -420,11 +420,11 @@ But if you insist, my apartment is actually pitifully easy to break into. That w
 
 Understand "force [something openable]" or "force [something openable] open" as opening.
 
-Rule for printing the name of my apartment while listing exits or facing:
+[Rule for printing the name of my apartment while listing exits or facing:
 	say "my apartment".
 
 Rule for printing the name of apartment bathroom while listing exits or facing:
-	say "apartment bathroom".
+	say "apartment bathroom".]
 
 After going through the bathroom window:
 	let N be the number of entries in the path so far of the player;
@@ -1058,7 +1058,7 @@ The description of the mailboxes is "There are slots for all the professors and 
 
 Section 5 - Higgate's Office
 
-Higgate's office is an office. It is privately-controlled, checkpoint and southern.
+Higgate's Office is an office. It is privately-controlled, checkpoint and southern.
 
 Higgate's office door is west of the Language Studies Department Office. Higgate's office door is a door. It is open and lockable and scenery. The description is "A nondescript office door with Professor Higgate's name on it." Understand "west door" or "name" as higgate's office door when the location is the Language Studies Department Office.
 
@@ -1917,7 +1917,7 @@ Rule for deciding the concealed possessions of Professor Brown:
 
 Section 11 - Lecture Hall
 
-Lecture Hall 1 is east of Samuel Johnson Basement. The description is "The main lecture hall used for large survey courses in language studies offered to undergraduates. I sat through courses here when I was an undergraduate myself, and have now delivered a few lectures as a teaching assistant." Lecture Hall 1 is indoors and southern and checkpoint.
+Lecture Hall 1 is east of Samuel Johnson Basement. The description is "The main lecture hall used for large survey courses in language studies offered to undergraduates. I sat through courses here when I was an undergraduate myself, and have now delivered a few lectures as a teaching assistant." Lecture Hall 1 is indoors, southern, improper-named and checkpoint.
 
 Out-direction of Lecture Hall 1 is west. [Back to Samuel Johnson basement]
 
@@ -1931,10 +1931,10 @@ The printed name is "Lecture Hall". Understand "podium" or "at podium" or "at th
 After printing the name of Lecture Hall 1 while not constructing the status line:
 	say " [roman type](at the [podium])".
 
-Instead of looking toward Lecture Hall 1 when the location is Samuel Johnson Basement:
+Rule for distantly describing Lecture Hall 1 when the location is Samuel Johnson Basement:
 	say "There is a lecture room to the east."
 
-Instead of looking toward Lecture Hall 1:
+Rule for distantly describing Lecture Hall 1:
 	say "[We] see the podium that way."
 
 The podium is a supporter in Lecture Hall 1. It is scenery. The description is "An advanced, pre-wired [podium] that allows the instructor to project slides from a laptop or show movies."
@@ -1973,13 +1973,13 @@ A dangerous destruction rule for the conference poster:
 Sanity-check looking under the conference poster when the conference poster is fixed in place:
 	say "That would be hard to do without ripping it off the wall." instead.
 
-Lecture Hall 2 is south of Lecture Hall 1. The printed name is "Lecture Hall". Understand "seats" or "among the seats" or "among seats" or "(among seats)" or "(among the seats)" as Lecture Hall 2. Lecture Hall 2 is indoors and southern.
+Lecture Hall 2 is south of Lecture Hall 1. The printed name is "Lecture Hall". Understand "seats" or "among the seats" or "among seats" or "(among seats)" or "(among the seats)" as Lecture Hall 2. Lecture Hall 2 is indoors, improper-named and southern.
 	The description is "Many are the fine hours I have spent here dozing; and many are the students of mine who have done the same. The circle of life becomes complete."
 
 After printing the name of Lecture Hall 2 while not constructing the status line:
 	say " [roman type](among the [if boldening is true][bold type][end if]seats[roman type])".
 
-Instead of looking toward Lecture Hall 2:
+Rule for distantly describing Lecture Hall 2:
 	say "[We] see the seats that way."
 
 Some wooden seats are supporters in Lecture Hall 2. Understand "hard" or "wood" as the wooden seats. The initial appearance is "The room extends [if Location is Lecture Hall 1]south[otherwise]north[end if], full of hard [wooden seats]." The description is "Ingeniously uncomfortable."

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/Act IV Among Policemen.i7x
@@ -556,7 +556,7 @@ Chapter 2 - Bureau Basement
 
 Section 1 - Foot of Stairs
 
-Below Bureau Hallway is Bureau Basement South. Bureau Basement South is indoors, forbidden and southern. Understand "bureau basement s" as Bureau Basement South. The description of Bureau Basement South is "[We] have descended into a windowless underground passage. The hallway runs [north] from here, and for an eerily long way [--] the tunnels must extend well beyond the above-ground profile of the building."
+Below Bureau Hallway is Bureau Basement South. Bureau Basement South is indoors, forbidden, improper-named, and southern. Understand "bureau basement s" as Bureau Basement South. The description of Bureau Basement South is "[We] have descended into a windowless underground passage. The hallway runs [north] from here, and for an eerily long way [--] the tunnels must extend well beyond the above-ground profile of the building."
 
 Out-direction of Bureau Basement South is up. [To bureau hallway]
 
@@ -616,7 +616,7 @@ Test automaton with "tutorial off / open tub / x automaton / put automaton in in
 
 Section 2 - Basement Middle
 
-North of Bureau Basement South is Bureau Basement Middle. It is indoors, forbidden and southern. The description of Bureau Basement Middle is "The hallway continues both [north] and [south], flanked by doors painted immutable col[our]s: hyacinth, celadon, chartreuse."
+North of Bureau Basement South is Bureau Basement Middle. It is indoors, forbidden, improper-named, and southern. The description of Bureau Basement Middle is "The hallway continues both [north] and [south], flanked by doors painted immutable col[our]s: hyacinth, celadon, chartreuse."
 
 The hyacinth door, the celadon door, and the chartreuse door are scenery in Bureau Basement Middle.
 
@@ -673,7 +673,7 @@ Some Hello Kitty stickers are part of the cute security door. The description is
 
 Section 3 - Secret Section
 
-Bureau Basement Secret Section is indoors, checkpoint, forbidden and southern. The description is "The heightened security on this side of the door is obvious everywhere [we] look. The floor is tiled in paisley tiles. The light fixtures give off pale pink light. The walls are covered in frog leather. The doors are locked with padlocks the size of handbags, locks decorated à la Louis Quinze, combination locks made of solid gold. There is not a bare noun in sight."
+Bureau Basement Secret Section is indoors, checkpoint, forbidden, improper-named, and southern. The description is "The heightened security on this side of the door is obvious everywhere [we] look. The floor is tiled in paisley tiles. The light fixtures give off pale pink light. The walls are covered in frog leather. The doors are locked with padlocks the size of handbags, locks decorated à la Louis Quinze, combination locks made of solid gold. There is not a bare noun in sight."
 
 Out-direction of Bureau Basement Secret Section is south. [Bureau basement middle]
 

--- a/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
+++ b/Counterfeit Monkey.materials/Extensions/Counterfeit Monkey/World Model Tweaks.i7x
@@ -965,13 +965,123 @@ Include Facing by Emily Short.
 Instead of examining a direction:
 	try facing the noun.
 
+Definition: a room is always-definite:
+	if it is visited:
+		yes;
+	if it is the old city walls:
+		yes;
+	if it is the new church:
+		yes;
+	if it is the cathedral gift shop:
+		yes;
+	if it is the church garden:
+		yes;
+	if it is the docks:
+		yes;
+	if it is the Aquarium Bookstore:
+		yes;
+	if it is the Counterfeit Monkey:
+		yes;
+	if it is the Babel Café:
+		yes;
+	if it is the Fleur d'Or lobby:
+		yes;
+	if it is the Fleur drinks club:
+		yes;
+	if it is the Babel Café:
+		yes;
+	if it is the rotunda:
+		yes;
+	if it is the university oval:
+		yes;
+	if it is the Language Studies seminar room:
+		yes;
+	if it is the Language Studies department office:
+		yes;
+	if it is the rectification room:
+		yes;
+	if it is the graduate student office:
+		yes;
+	if it is the Tools Exhibit:
+		yes;
+	if it is the Bureau Basement South:
+		yes;
+	if it is the Bureau Basement Middle:
+		yes;
+	if it is the Bureau Basement Secret Section:
+		yes;
+	if it is the sensitive equipment testing room:
+		yes;
+	if it is the equipment archive:
+		yes;
+	if it is the Oracle project:
+		yes;
+	if it is the cold storage:
+		yes;
+	if it is the display reloading room:
+		yes;
+	if it is the open sea:
+		yes;
+	if it is the shadow chamber:
+		yes;
+	if it is nautical:
+		yes;
+	no.
+
+To say in-sentence-room-name for (R - a room):
+	if R is My Apartment:
+		say "my apartment";
+	otherwise if R is Waterstone's Office:
+		say "Waterstone's office";
+	otherwise if R is Higgate's Office:
+		say "Higgate's office";
+	otherwise if R is Brown's lab:
+		say "Brown's lab";
+	otherwise if R is Fleur d'Or Lobby:
+		say "Fleur d'Or lobby";
+	otherwise if R is Fleur d'Or Drinks Club:
+		say "Fleur d'Or drinks club";
+	otherwise if R is Beside Slango's Ship:
+		say "Slango's ship";
+	otherwise if R is Brock's Stateroom:
+		say "Brock's stateroom";
+	otherwise if R is Brock's Head:
+		say "Brock's head";
+	otherwise if R is Slango's Bunk:
+		say "Slango's bunk";
+	otherwise if R is Slango's Head:
+		say "Slango's head";
+	otherwise if R is Your Bunk:
+		say "our bunk";
+	otherwise if R is Your Head:
+		say "our head";
+	otherwise if R is the Oracle Project:
+		say "Oracle project";
+	otherwise if R is the bureau hallway:
+		say "hallway";
+	otherwise if R is Bureau Basement South or R is Bureau Basement Middle or R is Bureau Basement Secret Section:
+		say "Bureau basement";
+	otherwise if R is Counterfeit Monkey or R is Aquarium Bookstore or R is Babel Café or R is New Church or R is the Oracle Project or R is proper-named:
+		say the printed name of R;
+	otherwise:
+		let N be the printed name of R;
+		now N is N in lower case;
+		say N;
+
 Rule for distantly describing a room (called target) (this is the new distant description rule):
-	say "[We] make out [the target] that way."
+	say "[We] make out [if target is always-definite][the target][otherwise][a target][end if] that way."
 
 The default distant description rule is not listed in any rulebook.
 
+Rule for printing the name of a room (called R) while listing exits or facing or distantly describing or describing path of something :
+	say "[in-sentence-room-name for R]".
+
+[When story begins:
+	repeat with R running through rooms:
+		carry out the distantly describing activity with the R.]
+
 Rule for distantly describing a room (called target) which encloses someone when the location is indoors:
-	say "That way [we] can see [the target], in which [is-are a list of people enclosed by the target]."
+	say "That way [we] can see [if target is always-definite][the target][otherwise][a target][end if], in which [is-are a list of people enclosed by the target]."
 
 Check looking toward a room (this is the new can't see through closed door rule):
 	now the occluding door is the door direction faced from the location;

--- a/tools/regtest/CM-regtest
+++ b/tools/regtest/CM-regtest
@@ -392,7 +392,7 @@ My backpack is stowed under a seat in the third row from the back. I figured tha
 
 /(There are a flash drive and a monocle in the backpack|The backpack contains a flash drive and a monocle).
 
-We can go north and east to the Cinema Lobby from here.
+We can go north and east to the cinema lobby from here.
 
 > get all
 /backpack: We (take|get|pick up|acquire) the backpack. Mine: a little bit worn, but capacious. It doesn't have any identifying marks on it, and I thought a brand-new bag would look more suspicious. It's closed.
@@ -1293,7 +1293,7 @@ Immediately west, the Counterfeit Monkey's sign sways in the wind.
 The snapping continues.
 
 > go to convenience
-/(We have a( quick| short| brief)?|It's a( short| quick| brief)?|We) drive through the marina district (over to|to|as far as) the Roundabout.
+/(We have a( quick| short| brief)?|It's a( short| quick| brief)?|We) drive through the marina district (over to|to|as far as) the roundabout.
 
 The whole Roundabout has ground to a halt, with protesters walking in the street and in some places completely filling the road. But this is mostly a nuisance until I notice that there are a couple of teenagers handcuffed to a tree.
 
@@ -1969,7 +1969,7 @@ The snapping continues.
 
 > w
 
-Higgate's office
+Higgate's Office
 Higgate got about 30% finished with a stylish decorating scheme and then got distracted, leaving everything in a unsettled state. A few of her books are arranged on a very nice rosewood bookshelf, which looks Asian and is ornamented with small figurines; all the rest of her library is stacked higgledy-piggledy in plastic cartons.
 
 Professor Higgate is sitting at an oval table, on which are spread an ugly yellow book, a sugar bowl, a teapot, and a romance novel in some heavily accented language. Higgate is the second reader on my dissertation committee, and a conlang expert — that is, Constructed Languages. It was a seminar with her that really got me thinking about utopian linguistics, and she's been very supportive, though cautious. She and Professor Waterstone don't always get along that well.
@@ -2711,7 +2711,7 @@ We dip out a pea-sized quantity of gel and rub it gently onto the otter. With an
 The snapping continues.
 
 > go to winding path
-/(We |We have a (rather tiring|lengthy|long) |We make the( rather tiring| lengthy| long)? |It's a( rather tiring| lengthy| long)? )(walk|hike) out from under the sycamores in the Oval and up Long Street (over to|as far as|to) the Monumental Staircase. From there we have an invigorating climb up, with the view of the sea getting better and better as we go \(but of course looking requires stopping to gaze back over our shoulder\).
+/(We |We have a (rather tiring|lengthy|long) |We make the( rather tiring| lengthy| long)? |It's a( rather tiring| lengthy| long)? )(walk|hike) out from under the sycamores in the Oval and up Long Street (over to|as far as|to) the monumental staircase. From there we have an invigorating climb up, with the view of the sea getting better and better as we go \(but of course looking requires stopping to gaze back over our shoulder\).
 
 We walk through the wealthy neighborhood to Roget Close. There we slip between the houses and down a path that looks as though it might lead to someone's back yard. No one has ever put up signage to correct this misapprehension because no one who lives around here is eager to encourage strangers on the private beach.
 
@@ -2944,7 +2944,7 @@ We reset the device to y. The sticky gives way to the now-familiar stick.
 The snapping continues.
 
 > go to tall street
-/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the University Oval.
+/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the university oval.
 
 University Oval
 This is the center of the university, a broad grassy oval shaded with sycamore trees and surrounded by buildings in brick or white stone.
@@ -3043,7 +3043,7 @@ We step on a twig before we back away again.
 
 It is a place that might have been developed long ago; only it is known that there are remains of Roman settlement here, and there is a risk that digging out the foundations would turn up some of those ruins, exposing a large number of Latin-language objects to the light of day. To prevent this catastrophe the whole area has been placed off limits to development.
 
-We can go southeast to the Bus Station and west to Tall Street from here.
+We can go southeast to the bus station and west to Tall Street from here.
 
 The snapping continues.
 
@@ -3053,7 +3053,7 @@ In contrast with the parks in the more savory parts of town, this is a bit of pa
 
 A twig lies in the grass.
 
-We can go southeast to the Bus Station and west to Tall Street from here.
+We can go southeast to the bus station and west to Tall Street from here.
 
 > listen
 The crowd to the west is noisy and getting noisier.
@@ -3228,7 +3228,7 @@ In contrast with the parks in the more savory parts of town, this is a bit of pa
 
 A twig lies in the grass.
 
-We can go southeast to the Bus Station and west to Tall Street from here.
+We can go southeast to the bus station and west to Tall Street from here.
 
 The snapping continues.
 
@@ -3329,7 +3329,7 @@ An instructive notice details the criteria for entry to the Bureau proper.
 
 Here to guard access to the rest of the building is a secretary on a tall stool. The secretary is carrying the Regulation Authentication Scope and wearing a pencil skirt and a plain white top.
 
-We can go north to the Rotunda and east from here.
+We can go north to the rotunda and east from here.
 
 She turns her eyes towards us but doesn't say anything.
 
@@ -3396,7 +3396,7 @@ Time passes.
 Bureau Hallway
 This is a long hallway with many doors leading off, the business of the bureau being varied and all-encompassing; it is for all essential purposes the chief organ of government in Atlantis, since only a few topics are brought to citizen referendum.
 
-We can go east, west to the Antechamber, and down from here.
+We can go east, west to the antechamber, and down from here.
 
 > e
 
@@ -3410,7 +3410,7 @@ I'm pretty sure that hanging out here is the best way to get caught in a hurry, 
 Bureau Hallway
 This is a long hallway with many doors leading off, the business of the bureau being varied and all-encompassing; it is for all essential purposes the chief organ of government in Atlantis, since only a few topics are brought to citizen referendum.
 
-We can go east to the All-Purpose Office, west to the Antechamber, and down from here.
+We can go east to the all-purpose office, west to the antechamber, and down from here.
 
 > d
 
@@ -3419,7 +3419,7 @@ We have descended into a windowless underground passage. The hallway runs north 
 
 Propped in the corner are some articles that were probably meant to be used as part of the Serial Comma Day Fair, but got confiscated instead: a seer automaton and a plywood cutout depicting Atlantida.
 
-We can go north and up to the Bureau Hallway from here.
+We can go north and up to the hallway from here.
 
 > n
 
@@ -4029,7 +4029,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. From the pulley above the portcullis hangs a counter.
 
-I can go east through the portcullis (closed) and up to the Surveillance Room from here.
+I can go east through the portcullis (closed) and up to the surveillance room from here.
 
 /(A breeze along the passage stirs the dust.|Something like the cry of a seagull comes down the passage.)?
 
@@ -4054,7 +4054,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-I can go east and west to the Surveillance Room from here.
+I can go east and west to the surveillance room from here.
 
 > e
 
@@ -4097,7 +4097,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-I can go east to the Generator Room and west to the Surveillance Room from here.
+I can go east to the generator room and west to the surveillance room from here.
 
 > plug dais into wall
 I plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -4132,7 +4132,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. There's a pulley and hook arrangement above the portcullis, but the hook is empty.
 
-I can go east through the portcullis (closed) and up to the Surveillance Room from here.
+I can go east through the portcullis (closed) and up to the surveillance room from here.
 
 > put counterweight on hook
 I hang the counterweight on the hook. The portcullis shifts slightly but doesn't rise on its own. Perhaps with a little help, though.
@@ -4254,7 +4254,7 @@ A set of children's playing jacks. They are lined up, with curious precision, in
 /I reset the device to s. There is a [a-z \-]+, and the jacks turn into a jack. A heavy-duty jack, suitable for raising cars or other substantial objects.
 
 > go to workshop
-/(It's a |I (make the ))?(short |quick |brief |)(walk|hike) (over to|as far as|to) the Personal Apartment. There I try propping the portcullis with the jack.
+/(It's a |I (make the ))?(short |quick |brief |)(walk|hike) (over to|as far as|to) the personal apartment. There I try propping the portcullis with the jack.
 
 /(Then|Next|After that|From there) (I |I have a (brief|quick|short) |I make the( brief| quick| short)? |it's a( brief| quick| short)? )(walk|hike).
 
@@ -4265,7 +4265,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-I can go east to the Generator Room and west to the Surveillance Room from here.
+I can go east to the generator room and west to the surveillance room from here.
 
 I definitely hear footsteps. And voices.
 
@@ -4790,7 +4790,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east and west to the Surveillance Room from here.
+You can go east and west to the surveillance room from here.
 
 > e
 
@@ -4839,7 +4839,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 > w
 
@@ -4855,7 +4855,7 @@ This is nothing less than the command center for a massive propaganda campaign. 
 
 /A filing cabinet stands in the corner. It (rests|is|sits) on a long table, alongside a paperweight.
 
-You can go south to Wonderland and east to the Surveillance Room from here.
+You can go south to Wonderland and east to the surveillance room from here.
 
 > gel paperweight
 You dip out a pea-sized quantity of gel and rub it gently onto the paperweight. With an audible SPLORT, the paperweight becomes a weight and a paper.
@@ -5057,7 +5057,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. From the pulley above the portcullis hangs a counter.
 
-You can go east through the portcullis (closed) and up to the Surveillance Room from here.
+You can go east through the portcullis (closed) and up to the surveillance room from here.
 
 > get counter
 /You (take|get|pick up|acquire) the counter. One of those devices with a press-button to increment a number, to assist with counting things like the number of people attending an event. There's also a loop to let the user wear it over one finger. The counter currently reads 17.
@@ -5078,7 +5078,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 > e
 
@@ -5119,7 +5119,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 > plug dais into wall
 You plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -5154,7 +5154,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. There's a pulley and hook arrangement above the portcullis, but the hook is empty.
 
-You can go east through the portcullis (closed) and up to the Surveillance Room from here.
+You can go east through the portcullis (closed) and up to the surveillance room from here.
 
 > put counterweight on hook
 You hang the counterweight on the hook. The portcullis shifts slightly but doesn't rise on its own. Perhaps with a little help, though.
@@ -5274,7 +5274,7 @@ A set of children's playing jacks. They are lined up, with curious precision, in
 /You reset the device to s. There is a [a-z \-]+, and the jacks turn into a jack. A heavy-duty jack, suitable for raising cars or other substantial objects.
 
 > go to workshop
-/(You|(It's|You have) a (quick|brief|short))|You make the( quick| brief| short)? (walk|hike) (over to|as far as|to) Personal Apartment. There you try propping the portcullis with the jack.
+/(You|(It's|You have) a (quick|brief|short))|You make the( quick| brief| short)? (walk|hike) (over to|as far as|to) personal apartment. There you try propping the portcullis with the jack.
 
 /(Then|Next|After that|From there) (you |you have a (brief|quick|short) |you make the( brief| quick| short)? |it's a( brief| quick| short)? )(walk|hike).
 
@@ -5285,7 +5285,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A cord snakes across the floor, connecting the dais socket to the wall socket.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 You definitely hear footsteps. And voices.
 

--- a/tools/regtest/CM-regtest-hard
+++ b/tools/regtest/CM-regtest-hard
@@ -244,7 +244,7 @@ My backpack is stowed under a seat in the third row from the back. I figured tha
 
 /(There are a flash drive and a monocle in the backpack|The backpack contains a flash drive and a monocle).
 
-We can go north and east to the Cinema Lobby from here.
+We can go north and east to the cinema lobby from here.
 
 > get all
 /backpack: We (take|get|pick up|acquire) the backpack. Mine: a little bit worn, but capacious. It doesn't have any identifying marks on it, and I thought a brand-new bag would look more suspicious. It's closed.
@@ -982,7 +982,7 @@ To the east, up a moderate rise from the sea-level docks, is the imposing exteri
 Immediately west, the Counterfeit Monkey's sign sways in the wind.
 
 > go to convenience
-/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )drive through the marina district (over to|to|as far as) the Roundabout.
+/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )drive through the marina district (over to|to|as far as) the roundabout.
 
 The whole Roundabout has ground to a halt, with protesters walking in the street and in some places completely filling the road. But this is mostly a nuisance until I notice that there are a couple of teenagers handcuffed to a tree.
 
@@ -1523,7 +1523,7 @@ To judge, however, from the angry asterisking, Waterstone is still looking for a
 
 > w
 
-Higgate's office
+Higgate's Office
 Higgate got about 30% finished with a stylish decorating scheme and then got distracted, leaving everything in a unsettled state. A few of her books are arranged on a very nice rosewood bookshelf, which looks Asian and is ornamented with small figurines; all the rest of her library is stacked higgledy-piggledy in plastic cartons.
 
 Professor Higgate is sitting at an oval table, on which are spread an ugly yellow book, a sugar bowl, a teapot, and a romance novel in some heavily accented language. Higgate is the second reader on my dissertation committee, and a conlang expert — that is, Constructed Languages. It was a seminar with her that really got me thinking about utopian linguistics, and she's been very supportive, though cautious. She and Professor Waterstone don't always get along that well.
@@ -2234,7 +2234,7 @@ We already have that.
 There is a continuous angry whine from the jigsaw.
 
 > go to tall street
-/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the University Oval.
+/(We |We have a (brief|quick|short) |We make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the university oval.
 
 University Oval
 This is the center of the university, a broad grassy oval shaded with sycamore trees and surrounded by buildings in brick or white stone.
@@ -2318,7 +2318,7 @@ We step on a bent twig before we back away again.
 
 It is a place that might have been developed long ago; only it is known that there are remains of Roman settlement here, and there is a risk that digging out the foundations would turn up some of those ruins, exposing a large number of Latin-language objects to the light of day. To prevent this catastrophe the whole area has been placed off limits to development.
 
-We can go southeast to the Bus Station and west to Tall Street from here.
+We can go southeast to the bus station and west to Tall Street from here.
 
 There is a continuous angry whine from the jigsaw.
 
@@ -2630,7 +2630,7 @@ An instructive notice details the criteria for entry to the Bureau proper.
 
 Here to guard access to the rest of the building is a secretary on a tall stool. The secretary is carrying the Regulation Authentication Scope and wearing a pencil skirt and a plain white top.
 
-We can go north to the Rotunda and east from here.
+We can go north to the rotunda and east from here.
 
 She turns her eyes towards us but doesn't say anything.
 
@@ -2698,7 +2698,7 @@ Time passes.
 Bureau Hallway
 This is a long hallway with many doors leading off, the business of the bureau being varied and all-encompassing; it is for all essential purposes the chief organ of government in Atlantis, since only a few topics are brought to citizen referendum.
 
-We can go east, west to the Antechamber, and down from here.
+We can go east, west to the antechamber, and down from here.
 
 > e
 
@@ -2712,7 +2712,7 @@ I'm pretty sure that hanging out here is the best way to get caught in a hurry, 
 Bureau Hallway
 This is a long hallway with many doors leading off, the business of the bureau being varied and all-encompassing; it is for all essential purposes the chief organ of government in Atlantis, since only a few topics are brought to citizen referendum.
 
-We can go east to the All-Purpose Office, west to the Antechamber, and down from here.
+We can go east to the all-purpose office, west to the antechamber, and down from here.
 
 > d
 
@@ -2721,7 +2721,7 @@ We have descended into a windowless underground passage. The hallway runs north 
 
 Propped in the corner are some articles that were probably meant to be used as part of the Serial Comma Day Fair, but got confiscated instead: a seer automaton and a plywood cutout depicting Atlantida.
 
-We can go north and up to the Bureau Hallway from here.
+We can go north and up to the hallway from here.
 
 > n
 
@@ -3210,7 +3210,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. From the pulley above the portcullis hangs a counter.
 
-You can go east through the portcullis (closed) and up to the Surveillance Room from here.
+You can go east through the portcullis (closed) and up to the surveillance room from here.
 
 > get counter
 /You (get|take|pick up|acquire) the counter. One of those devices with a press-button to increment a number, to assist with counting things like the number of people attending an event. There's also a loop to let the user wear it over one finger. The counter currently reads 17.
@@ -3233,7 +3233,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east and west to the Surveillance Room from here.
+You can go east and west to the surveillance room from here.
 
 > e
 
@@ -3282,7 +3282,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 > plug dais into wall
 You plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -3314,7 +3314,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. There's a pulley and hook arrangement above the portcullis, but the hook is empty.
 
-You can go east through the portcullis (closed) and up to the Surveillance Room from here.
+You can go east through the portcullis (closed) and up to the surveillance room from here.
 
 > put counterweight on hook
 You hang the counterweight on the hook. The portcullis shifts slightly but doesn't rise on its own. Perhaps with a little help, though.
@@ -3436,7 +3436,7 @@ A set of children's playing jacks. They are lined up, with curious precision, in
 /You reset the device to s. There is a [a-z \-]+, and the jacks turn into a jack. A heavy-duty jack, suitable for raising cars or other substantial objects.
 
 > go to workshop
-/(You |You have a (brief|quick|short) |You make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the Personal Apartment. There you try propping the portcullis with the jack.
+/(You |You have a (brief|quick|short) |You make the( brief| quick| short)? |It's a( brief| quick| short)? )(walk|hike) (over to|as far as|to) the personal apartment. There you try propping the portcullis with the jack.
 
 /(Then|Next|After that|From there) (you |you have a (brief|quick|short) |you make the( brief| quick| short)? |it's a( brief| quick| short)? )(walk|hike).
 
@@ -3447,7 +3447,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-You can go east to the Generator Room and west to the Surveillance Room from here.
+You can go east to the generator room and west to the surveillance room from here.
 
 You definitely hear footsteps. And voices.
 

--- a/tools/regtest/CM-regtest-tests
+++ b/tools/regtest/CM-regtest-tests
@@ -551,7 +551,7 @@ This road descends steeply from southwest to northwest, passing between white co
 
 The Aquarium Bookstore is to the east. It is an esoteric bookstore (and purveyor of other things), but one whose owner has helped you in the past.
 
-We can go northwest, southwest to the Roundabout, east, and west from here.
+We can go northwest, southwest to the roundabout, east, and west from here.
 
 The car is making an unpleasant raspy growl.
 
@@ -619,7 +619,7 @@ Not very fishy at the moment, in fact: all the real trade happens in the early m
 
 Just east of here is a rusting corrugated tin building, which was built to house various possessions of the fishermen.
 
-We can go north, south, southeast to Deep Street, and east to the Tin Hut from here.
+We can go north, south, southeast to Deep Street, and east to the tin hut from here.
 
 >se
 
@@ -630,7 +630,7 @@ The Aquarium Bookstore is to the east. It's dim inside, but occasional movements
 
 /Our car ?(— which might better be described as a covered bicycle — )is parked nearby.
 
-We can go northwest to the Fish Market, southwest to the Roundabout, east, and west from here.
+We can go northwest to the fish market, southwest to the roundabout, east, and west from here.
 
 >get in car
 We get into the car.
@@ -705,7 +705,7 @@ Various tarpaulin-covered masses fill the room.
 A trap door is set in the floor.
 
 >u
-There is no way upwards. We can go west to the Fish Market and down through the trap door to the Crawlspace from here.
+There is no way upwards. We can go west to the fish market and down through the trap door to the crawlspace from here.
 
 The trap-door makes a creaking noise and slams shut again.
 
@@ -1407,7 +1407,7 @@ My backpack is stowed under a seat in the third row from the back. I figured tha
 
 /((In the backpack are|The backpack contains) a flash drive and a monocle|There are a flash drive and a monocle in the backpack).
 
-We can go north to the Projection Booth and east from here.
+We can go north to the projection booth and east from here.
 
 /(On the screen|In the movie|As we watch), a (skinny spinster kneels in the dirt, burying eggs in a row as though they were tulip bulbs. It's impossible to make out what's being said, but the music is melancholy, played on a distressed fiddle|woman clings to the lapels of a sharply-dressed gentleman. He pushes her away. She takes off a brooch shaped like a rooster and flings it at his feet. He picks it up and slowly pins it to his tie|man in a black uniform is making a fuss over a white rabbit in a cage).
 
@@ -1988,7 +1988,7 @@ We run some water from the sink tap over the funnel, leaving it glistening and c
 We run some water from the sink tap over the funnel, leaving it glistening and clean.
 
 >gonear Aquarium Bookstore
-Which do you mean, 1) Aquarium Bookstore or 2) Aquarium Bookstore?
+Which do you mean, 1) Aquarium Bookstore or the 2) Aquarium Bookstore?
 
 >2
 Aquarium Bookstore
@@ -2053,7 +2053,7 @@ This road descends steeply from southwest to northwest, passing between white co
 
 The Aquarium Bookstore is to the east. It is an esoteric bookstore (and purveyor of other things), but one whose owner has helped you in the past.
 
-We can go northwest, southwest, east to Aquarium Bookstore, and west from here.
+We can go northwest, southwest, east to the Aquarium Bookstore, and west from here.
 
 #tinhut
 
@@ -2626,10 +2626,10 @@ Oh so tempting. You're not the first person to think of it, trust me. The underg
 #page
 
 >gonear Lecture Hall
-Which do you mean, 1) Lecture Hall (at the podium) or 2) Lecture Hall (among the seats)?
+Which do you mean, the 1) Lecture Hall (at the podium) or the 2) Lecture Hall (among the seats)?
 
 >1
-(Lecture Hall (at the podium))
+(the Lecture Hall (at the podium))
 Lecture Hall (at the podium)
 The main lecture hall used for large survey courses in language studies offered to undergraduates. I sat through courses here when I was an undergraduate myself, and have now delivered a few lectures as a teaching assistant.
 
@@ -4906,7 +4906,7 @@ A power cord snakes across the floor, connecting the dais socket to the wall soc
 
 The son is here.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >turn on platform
 An indicator message lights up: FAIL: TWO OBJECTS REQUIRED FOR SYNTHESIS.
@@ -5023,7 +5023,7 @@ A room whose importance is obvious from how clean it is and how little furniture
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >turn on platform
 An indicator message lights up: FAIL: TWO OBJECTS REQUIRED FOR SYNTHESIS.
@@ -5252,7 +5252,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >plug in dais
 We plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -5370,7 +5370,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >plug in dais
 We plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -5887,7 +5887,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >purloin spot
 [Purloined.]
@@ -5979,7 +5979,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >put screws on platform
 We put the screws on the programmable dais.
@@ -6460,7 +6460,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >purloin power cord
 [Purloined.]
@@ -6504,7 +6504,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west from here.
+We can go east to the generator room and west from here.
 
 >put shuttle on dais
 We put the shuttle on the programmable dais.
@@ -7541,7 +7541,7 @@ The footpath winds between the villas, sloping steeply downward. It is narrow, a
 
 #clerk
 >gonear Babel Cafe
-(Babel Café)
+(the Babel Café)
 Babel Café
 Through many changes of management, this institution has fed the denizens of the university and ignored their semi-sedition.
 
@@ -7580,7 +7580,7 @@ The clerk gets out a honey triangle and puts it on the table, then locks up the 
 >{include} restart
 #clerk2
 >gonear Babel Cafe
-(Babel Café)
+(the Babel Café)
 Babel Café
 Through many changes of management, this institution has fed the denizens of the university and ignored their semi-sedition.
 
@@ -9372,7 +9372,7 @@ We could thank the bartender.
 
 #lena
 >gonear Aquarium Bookstore.
-Which do you mean, 1) Aquarium Bookstore or 2) Aquarium Bookstore?
+Which do you mean, 1) Aquarium Bookstore or the 2) Aquarium Bookstore?
 
 >2
 Aquarium Bookstore
@@ -9515,7 +9515,7 @@ This road descends steeply from southwest to northwest, passing between white co
 
 The Aquarium Bookstore is to the east. It is an esoteric bookstore (and purveyor of other things), but one whose owner has helped you in the past.
 
-We can go northwest, southwest, east to Aquarium Bookstore, and west from here.
+We can go northwest, southwest, east to the Aquarium Bookstore, and west from here.
 
 >car-acquire
 Deep Street
@@ -9525,7 +9525,7 @@ Our pathetic little car is parked right outside Aquarium Bookstore. Here is how 
 
 Suffice it to say that we are not similarly blessed.
 
-We can go northwest, southwest, east to Aquarium Bookstore, and west from here.
+We can go northwest, southwest, east to the Aquarium Bookstore, and west from here.
 
 >start car
 We swing the car door open.
@@ -9590,7 +9590,7 @@ This road descends steeply from southwest to northwest, passing between white co
 
 The Aquarium Bookstore is to the east. It's dim inside, but occasional movements suggest that the proprietor, Slango's friend Lena, is inside.
 
-We can go northwest, southwest to the Roundabout, east to Aquarium Bookstore, and west from here.
+We can go northwest, southwest to the roundabout, east to the Aquarium Bookstore, and west from here.
 
 The car is making an unpleasant raspy growl.
 
@@ -9922,7 +9922,7 @@ We could ask for privacy or ask whether she had trouble with customs.
 
 #barman
 >gonear Counterfeit Monkey
-Which do you mean, the 1) Counterfeit Monkey Bar, the 2) pub, or 3) Counterfeit Monkey?
+Which do you mean, the 1) Counterfeit Monkey Bar, the 2) pub, or the 3) Counterfeit Monkey?
 
 >3
 Counterfeit Monkey
@@ -10067,7 +10067,7 @@ I giggle sharply, a nervous little titter that makes Slango look at us distrustf
 >{include} restart
 
 >gonear Counterfeit Monkey
-Which do you mean, the 1) Counterfeit Monkey Bar, the 2) pub, or 3) Counterfeit Monkey?
+Which do you mean, the 1) Counterfeit Monkey Bar, the 2) pub, or the 3) Counterfeit Monkey?
 
 >3
 Counterfeit Monkey
@@ -10892,7 +10892,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east and west to the Surveillance Room from here.
+We can go east and west to the surveillance room from here.
 
 >e
 
@@ -10919,7 +10919,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east to the Generator Room and west to the Surveillance Room from here.
+We can go east to the generator room and west to the surveillance room from here.
 
 >plug in cord
 We plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -10940,7 +10940,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. From the pulley above the portcullis hangs a counter.
 
-We can go east through the portcullis (closed) and up to the Surveillance Room from here.
+We can go east through the portcullis (closed) and up to the surveillance room from here.
 
 A breeze along the passage stirs the dust.
 
@@ -10957,7 +10957,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west to the Surveillance Room from here.
+We can go east to the generator room and west to the surveillance room from here.
 
 >put counter and weight on dais
 counter: Done.
@@ -10984,7 +10984,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. There's a pulley and hook arrangement above the portcullis, but the hook is empty.
 
-We can go east through the portcullis (closed) and up to the Surveillance Room from here.
+We can go east through the portcullis (closed) and up to the surveillance room from here.
 
 >put counterweight on hook
 We hang the counterweight on the hook. The portcullis shifts slightly but doesn't rise on its own. Perhaps with a little help, though.
@@ -11392,7 +11392,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east and west to the Surveillance Room from here.
+We can go east and west to the surveillance room from here.
 
 >e
 
@@ -11419,7 +11419,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A specialized wall socket is built into the east wall, clearly not part of the ordinary power system for the Bureau.
 
-We can go east to the Generator Room and west to the Surveillance Room from here.
+We can go east to the generator room and west to the surveillance room from here.
 
 >plug in cord
 We plug the power cord firmly into the dais socket. The other end remains free and not plugged into anything.
@@ -11440,7 +11440,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. From the pulley above the portcullis hangs a counter.
 
-We can go east through the portcullis (closed) and up to the Surveillance Room from here.
+We can go east through the portcullis (closed) and up to the surveillance room from here.
 
 The air stirs with a breeze from the east.
 
@@ -11457,7 +11457,7 @@ A programmable dais sits in the middle of the room. It has the raw look of lab e
 
 A power cord snakes across the floor, connecting the dais socket to the wall socket.
 
-We can go east to the Generator Room and west to the Surveillance Room from here.
+We can go east to the generator room and west to the surveillance room from here.
 
 >put counter and weight on dais
 counter: Done.
@@ -11484,7 +11484,7 @@ This passage has been cut through natural cliff rock and looks older than the Bu
 
 Blocking the far end of the corridor is a metal portcullis. It is currently lowered. There's a pulley and hook arrangement above the portcullis, but the hook is empty.
 
-We can go east through the portcullis (closed) and up to the Surveillance Room from here.
+We can go east through the portcullis (closed) and up to the surveillance room from here.
 
 >put counterweight on hook
 We hang the counterweight on the hook. The portcullis shifts slightly but doesn't rise on its own. Perhaps with a little help, though.
@@ -12277,7 +12277,7 @@ A fairly natural-looking extension, red in color, attachable by comb. It should 
 We settle the red hairpiece on our head and adjust our hair underneath.
 
 >gonear cafe
-Which do you mean, 1) where the Babel Café is, the 2) Outdoor Café, the 3) café building, or 4) Babel Café?
+Which do you mean, 1) where the Babel Café is, the 2) Outdoor Café, the 3) café building, or the 4) Babel Café?
 
 >2
 Outdoor Café


### PR DESCRIPTION
An attempt to make the use of room names in sentences more natural. This affects listing exits, "can't go that way" messages, looking into adjacent rooms, and reporting travelling longer distances.

Changes things like "We can see Slango's Bunk that way" to "We can see Slango's bunk that way."

Also tries to deal with proper-named rooms that have a definite article, such as The Counterfeit Monkey or The Aquarium bookstore. Not sure if the approach used, making them improper-named, is the best one, though.